### PR TITLE
redirect all old links to homepage

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,4 +10,6 @@
 exports.createPages = ({ graphql, actions }) => {
     const {createRedirect} = actions //actions is collection of many actions - https://www.gatsbyjs.org/docs/actions
     createRedirect({ fromPath: '/donate', toPath: 'https://donorbox.org/donate-to-justfix-nyc', isPermanent: true });
+    createRedirect({ fromPath: '/get-repairs', toPath: '/', isPermanent: true });
+    createRedirect({ fromPath: '/about/products-and-services', toPath: '/#products', isPermanent: true });
   }


### PR DESCRIPTION
reviewed any old links still cached in site:www.justfix.nyc: 
`get-repairs` -> homepage
`about/products-and-services` -> homepage products section 
