### PR TITLE
Fully internationalize non-Contentful text

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -25,33 +25,33 @@ const Footer = withI18n()(({locale, i18n}: Locale & withI18nProps) => {
         </div>
         <div className="column is-one-quarter">
           <p className="link-header has-text-white has-text-weight-bold">WHAT WE DO</p>
-          <Link className="link has-text-weight-semibold" to={localePrefix + "/#products"}>
-            <p><Trans>PRODUCTS &amp; SERVICES</Trans></p>
+          <Link className="link has-text-weight-semibold is-uppercase" to={localePrefix + "/#products"}>
+            <p><Trans>Products &amp; Services</Trans></p>
           </Link>
-          <Link className="link has-text-weight-semibold" to={localePrefix + "/our-mission"}>
-            <p><Trans>OUR MISSION</Trans></p>
+          <Link className="link has-text-weight-semibold is-uppercase" to={localePrefix + "/our-mission"}>
+            <p><Trans>Our mission</Trans></p>
           </Link>
-          <Link className="link has-text-weight-semibold" to={localePrefix + "/contact-us"}>
-            <p><Trans>CONTACT</Trans></p>
+          <Link className="link has-text-weight-semibold is-uppercase" to={localePrefix + "/contact-us"}>
+            <p><Trans>Contact</Trans></p>
           </Link>
-          <a className="link has-text-weight-semibold" href="https://donorbox.org/donate-to-justfix-nyc" target="_blank" rel="noopener noreferrer">
-            <p><Trans>DONATE</Trans></p>
+          <a className="link has-text-weight-semibold is-uppercase" href="https://donorbox.org/donate-to-justfix-nyc" target="_blank" rel="noopener noreferrer">
+            <p><Trans>Donate</Trans></p>
           </a>
         </div>
 
         <div className="column is-one-quarter">
           <p className="link-header has-text-white has-text-weight-bold"><Trans>ABOUT US</Trans></p>
-          <Link className="link has-text-weight-semibold" to={localePrefix + "/about/team"}>
-            <p><Trans>OUR TEAM</Trans></p>
+          <Link className="link has-text-weight-semibold is-uppercase" to={localePrefix + "/about/team"}>
+            <p><Trans>Our team</Trans></p>
           </Link>
-          <Link className="link has-text-weight-semibold" to={localePrefix + "/about/partners"}>
-            <p><Trans>OUR PARTNERS</Trans></p>
+          <Link className="link has-text-weight-semibold is-uppercase" to={localePrefix + "/about/partners"}>
+            <p><Trans>Our partners</Trans></p>
           </Link>
-          <a className="link has-text-weight-semibold" href="https://justfix.breezy.hr/" target="_blank" rel="noopener noreferrer">
-            <p><Trans>JOBS</Trans></p>
+          <a className="link has-text-weight-semibold is-uppercase" href="https://justfix.breezy.hr/" target="_blank" rel="noopener noreferrer">
+            <p><Trans>Jobs</Trans></p>
           </a>
-          <Link className="link has-text-weight-semibold" to={localePrefix + "/about/press"}>
-            <p><Trans>PRESS</Trans></p>
+          <Link className="link has-text-weight-semibold is-uppercase" to={localePrefix + "/about/press"}>
+            <p><Trans>Press</Trans></p>
           </Link>
         </div>
 
@@ -65,8 +65,8 @@ const Footer = withI18n()(({locale, i18n}: Locale & withI18nProps) => {
                   <input type="email" name="EMAIL" className="required email input" id="mce-EMAIL" placeholder={i18n._(t`Email Address`)} />
               </div>
               <div className="control has-text-centered-mobile">
-                <button className="button is-primary" type="submit">
-                    <Trans>SIGN UP</Trans>
+                <button className="button is-primary is-uppercase" type="submit">
+                    <Trans>Sign up</Trans>
                 </button>
               </div>
             </div>
@@ -86,11 +86,11 @@ const Footer = withI18n()(({locale, i18n}: Locale & withI18nProps) => {
         <div className="column is-three-quarters">
           <p className="subtitle is-size-6 has-text-white"><Trans><b>Disclaimer:</b> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</Trans></p>
           <p className="subtitle is-size-6 has-text-white"><Trans><b>JustFix.nyc</b> is a registered 501(c)(3) nonprofit organization.</Trans></p>
-          <Link className="link legal has-text-weight-semibold" to={localePrefix + "/privacy-policy"}>
-            <Trans>PRIVACY POLICY</Trans>
+          <Link className="link legal has-text-weight-semibold is-uppercase" to={localePrefix + "/privacy-policy"}>
+            <Trans>Privacy policy</Trans>
           </Link>
-          <Link className="link legal has-text-weight-semibold" to={localePrefix + "/terms-of-use"}>
-            <Trans>TERMS OF USE</Trans>
+          <Link className="link legal has-text-weight-semibold is-uppercase" to={localePrefix + "/terms-of-use"}>
+            <Trans>Terms of use</Trans>
           </Link>
         </div>
         <div className="column is-one-quarter">

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -40,7 +40,7 @@ const Footer = withI18n()(({locale, i18n}: Locale & withI18nProps) => {
         </div>
 
         <div className="column is-one-quarter">
-          <p className="link-header has-text-white has-text-weight-bold"><Trans>ABOUT US</Trans></p>
+          <p className="link-header has-text-white has-text-weight-bold is-uppercase"><Trans>About us</Trans></p>
           <Link className="link has-text-weight-semibold is-uppercase" to={localePrefix + "/about/team"}>
             <p><Trans>Our team</Trans></p>
           </Link>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { SocialIcon } from 'react-social-icons';
 import { Link } from 'gatsby'
+import { Trans } from '@lingui/macro';
 
 import '../styles/footer.scss' 
 import { Locale } from '../pages';
@@ -24,38 +25,38 @@ const Footer = ({locale}: Locale) => {
         <div className="column is-one-quarter">
           <p className="link-header has-text-white has-text-weight-bold">WHAT WE DO</p>
           <Link className="link has-text-weight-semibold" to={localePrefix + "/#products"}>
-            <p>PRODUCTS & SERVICES</p>
+            <p><Trans>PRODUCTS &amp; SERVICES</Trans></p>
           </Link>
           <Link className="link has-text-weight-semibold" to={localePrefix + "/our-mission"}>
-            <p>OUR MISSION</p>
+            <p><Trans>OUR MISSION</Trans></p>
           </Link>
           <Link className="link has-text-weight-semibold" to={localePrefix + "/contact-us"}>
-            <p>CONTACT</p>
+            <p><Trans>CONTACT</Trans></p>
           </Link>
           <a className="link has-text-weight-semibold" href="https://donorbox.org/donate-to-justfix-nyc" target="_blank" rel="noopener noreferrer">
-            <p>DONATE</p>
+            <p><Trans>DONATE</Trans></p>
           </a>
         </div>
 
         <div className="column is-one-quarter">
-          <p className="link-header has-text-white has-text-weight-bold">ABOUT US</p>
+          <p className="link-header has-text-white has-text-weight-bold"><Trans>ABOUT US</Trans></p>
           <Link className="link has-text-weight-semibold" to={localePrefix + "/about/team"}>
-            <p>OUR TEAM</p>
+            <p><Trans>OUR TEAM</Trans></p>
           </Link>
           <Link className="link has-text-weight-semibold" to={localePrefix + "/about/partners"}>
-            <p>OUR PARTNERS</p>
+            <p><Trans>OUR PARTNERS</Trans></p>
           </Link>
           <a className="link has-text-weight-semibold" href="https://justfix.breezy.hr/" target="_blank" rel="noopener noreferrer">
-            <p>JOBS</p>
+            <p><Trans>JOBS</Trans></p>
           </a>
           <Link className="link has-text-weight-semibold" to={localePrefix + "/about/press"}>
-            <p>PRESS</p>
+            <p><Trans>PRESS</Trans></p>
           </Link>
         </div>
 
         <div className="column is-one-quarter">
           <h4 className="title is-size-5 has-text-white">
-            Join our mailing list!
+            <Trans>Join our mailing list!</Trans>
           </h4>
           <form action={MAILCHIMP_URL} className="email-form is-horizontal-center" method="post" target="_blank">
             <div className="mc-field-group">
@@ -64,7 +65,7 @@ const Footer = ({locale}: Locale) => {
               </div>
               <div className="control has-text-centered-mobile">
                 <button className="button is-primary" type="submit">
-                    SIGN UP
+                    <Trans>SIGN UP</Trans>
                 </button>
               </div>
             </div>
@@ -82,13 +83,13 @@ const Footer = ({locale}: Locale) => {
 
       <div className="columns">
         <div className="column is-three-quarters">
-          <p className="subtitle is-size-6 has-text-white"><b>Disclaimer: </b>The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</p>
-          <p className="subtitle is-size-6 has-text-white"><b>JustFix.nyc </b>is a registered 501(c)(3) nonprofit organization.</p>
+          <p className="subtitle is-size-6 has-text-white"><Trans><b>Disclaimer:</b> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary.</Trans></p>
+          <p className="subtitle is-size-6 has-text-white"><Trans><b>JustFix.nyc</b> is a registered 501(c)(3) nonprofit organization.</Trans></p>
           <Link className="link legal has-text-weight-semibold" to={localePrefix + "/privacy-policy"}>
-            PRIVACY POLICY
+            <Trans>PRIVACY POLICY</Trans>
           </Link>
           <Link className="link legal has-text-weight-semibold" to={localePrefix + "/terms-of-use"}>
-            TERMS OF USE
+            <Trans>TERMS OF USE</Trans>
           </Link>
         </div>
         <div className="column is-one-quarter">

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import { SocialIcon } from 'react-social-icons';
 import { Link } from 'gatsby'
-import { Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { withI18n, withI18nProps } from '@lingui/react';
 
 import '../styles/footer.scss' 
 import { Locale } from '../pages';
@@ -9,7 +10,7 @@ import { Locale } from '../pages';
 const MAILCHIMP_URL = "https://nyc.us13.list-manage.com/subscribe/post?u=d4f5d1addd4357eb77c3f8a99&amp;id=588f6c6ef4";
 
 
-const Footer = ({locale}: Locale) => { 
+const Footer = withI18n()(({locale, i18n}: Locale & withI18nProps) => {
 
   const localePrefix = locale ? ("/" + locale) : "";
   
@@ -61,7 +62,7 @@ const Footer = ({locale}: Locale) => {
           <form action={MAILCHIMP_URL} className="email-form is-horizontal-center" method="post" target="_blank">
             <div className="mc-field-group">
               <div className="control is-expanded">
-                  <input type="email" name="EMAIL" className="required email input" id="mce-EMAIL" placeholder="Email Address" />
+                  <input type="email" name="EMAIL" className="required email input" id="mce-EMAIL" placeholder={i18n._(t`Email Address`)} />
               </div>
               <div className="control has-text-centered-mobile">
                 <button className="button is-primary" type="submit">
@@ -100,6 +101,6 @@ const Footer = ({locale}: Locale) => {
       </div>
 
     </div>
-  )};
+  )});
 
 export default Footer;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -48,8 +48,8 @@ render() {
       <div className="navbar-end">
 
         <div className="navbar-item has-dropdown is-hoverable">
-          <a className={"navbar-link has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
-            <Trans>ABOUT US</Trans>
+          <a className={"navbar-link is-uppercase has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
+            <Trans>About us</Trans>
           </a>
 
           <div className="navbar-dropdown">
@@ -68,12 +68,12 @@ render() {
           </div>
         </div>
 
-        <Link to={localePrefix + "/our-mission"} className={"navbar-item has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
-          <Trans>MISSION</Trans>
+        <Link to={localePrefix + "/our-mission"} className={"navbar-item is-uppercase has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
+          <Trans>Mission</Trans>
         </Link>
 
-        <Link to={localePrefix + "/contact-us"} className={"navbar-item has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
-          <Trans>CONTACT</Trans>
+        <Link to={localePrefix + "/contact-us"} className={"navbar-item is-uppercase has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
+          <Trans>Contact</Trans>
         </Link>
 
         {/* <Link to={this.props.locale === 'es' ? "/" : "/es"} className={"navbar-item has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
@@ -81,15 +81,15 @@ render() {
         </Link> */}
 
         {this.state.burgerMenuIsOpen && 
-        <a className="navbar-item has-text-black" href="https://app.justfix.nyc/login">
-          <Trans>SIGN IN</Trans>
+        <a className="navbar-item has-text-black is-uppercase" href="https://app.justfix.nyc/login">
+          <Trans>Sign in</Trans>
         </a>}
 
       </div>
         <div className="navbar-item">
           <div className="buttons">
-            <a className="button is-primary is-inverted is-outlined" href="https://app.justfix.nyc/login">
-              <Trans>SIGN IN</Trans>
+            <a className="button is-primary is-uppercase is-inverted is-outlined" href="https://app.justfix.nyc/login">
+              <Trans>Sign in</Trans>
             </a>
         </div>
       </div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -54,26 +54,26 @@ render() {
 
           <div className="navbar-dropdown">
             <Link to={localePrefix + "/about/partners"} className="navbar-item">
-              Our Partners 
+              <Trans>Our Partners</Trans>
             </Link>
             <Link to={localePrefix + "/about/team"} className="navbar-item">
-              Our Team 
+              <Trans>Our Team</Trans>
             </Link>
             <Link to={localePrefix + "/about/press"} className="navbar-item">
-              Press 
+              <Trans>Press</Trans>
             </Link>
             <a href="https://justfix.breezy.hr/" target="_blank" rel="noopener noreferrer" className="navbar-item">
-              Jobs 
+              <Trans>Jobs</Trans>
             </a>
           </div>
         </div>
 
         <Link to={localePrefix + "/our-mission"} className={"navbar-item has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
-          MISSION
+          <Trans>MISSION</Trans>
         </Link>
 
         <Link to={localePrefix + "/contact-us"} className={"navbar-item has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
-          CONTACT
+          <Trans>CONTACT</Trans>
         </Link>
 
         {/* <Link to={this.props.locale === 'es' ? "/" : "/es"} className={"navbar-item has-text-" + (this.state.burgerMenuIsOpen ? "black" : "white")}>
@@ -82,14 +82,14 @@ render() {
 
         {this.state.burgerMenuIsOpen && 
         <a className="navbar-item has-text-black" href="https://app.justfix.nyc/login">
-          SIGN IN
+          <Trans>SIGN IN</Trans>
         </a>}
 
       </div>
         <div className="navbar-item">
           <div className="buttons">
             <a className="button is-primary is-inverted is-outlined" href="https://app.justfix.nyc/login">
-              SIGN IN
+              <Trans>SIGN IN</Trans>
             </a>
         </div>
       </div>

--- a/src/components/read-more.tsx
+++ b/src/components/read-more.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Link } from 'gatsby'
+import { Trans } from '@lingui/macro';
 
 import '../styles/read-more.scss' 
 import { Locale } from '../pages';
@@ -15,7 +16,7 @@ const ReadMore = ({ title, link, locale }: Props) => (
             <div className="level-left">
                 <div className="level-item">
                     <div>
-                        <p className="title has-text-info is-size-6">Want to know more?</p>
+                        <p className="title has-text-info is-size-6"><Trans>Want to know more?</Trans></p>
                         <p className="title has-text-white is-size-4">{title}</p>
                     </div>
                     <div className="is-hidden-tablet">

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,6 +13,100 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/footer.tsx:79
+msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
+msgstr ""
+
+#: src/components/footer.tsx:80
+msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
+msgstr ""
+
+#: src/components/footer.tsx:35
 #: src/components/header.tsx:34
-msgid "ABOUT US"
+msgid "About us"
+msgstr ""
+
+#: src/components/footer.tsx:27
+#: src/components/header.tsx:58
+msgid "Contact"
+msgstr ""
+
+#: src/components/footer.tsx:30
+msgid "Donate"
+msgstr ""
+
+#: src/components/footer.tsx:57
+#: src/pages/contact-us.tsx:40
+msgid "Email Address"
+msgstr ""
+
+#: src/components/footer.tsx:43
+#: src/components/header.tsx:48
+msgid "Jobs"
+msgstr ""
+
+#: src/components/footer.tsx:52
+msgid "Join our mailing list!"
+msgstr ""
+
+#: src/components/header.tsx:54
+msgid "Mission"
+msgstr ""
+
+#: src/pages/404.tsx:7
+msgid "Not found"
+msgstr ""
+
+#: src/components/header.tsx:39
+msgid "Our Partners"
+msgstr ""
+
+#: src/components/header.tsx:42
+msgid "Our Team"
+msgstr ""
+
+#: src/components/footer.tsx:24
+msgid "Our mission"
+msgstr ""
+
+#: src/components/footer.tsx:40
+msgid "Our partners"
+msgstr ""
+
+#: src/components/footer.tsx:37
+msgid "Our team"
+msgstr ""
+
+#: src/components/footer.tsx:46
+#: src/components/header.tsx:45
+msgid "Press"
+msgstr ""
+
+#: src/components/footer.tsx:82
+msgid "Privacy policy"
+msgstr ""
+
+#: src/components/footer.tsx:21
+msgid "Products & Services"
+msgstr ""
+
+#: src/components/header.tsx:65
+#: src/components/header.tsx:72
+msgid "Sign in"
+msgstr ""
+
+#: src/components/footer.tsx:61
+msgid "Sign up"
+msgstr ""
+
+#: src/components/footer.tsx:85
+msgid "Terms of use"
+msgstr ""
+
+#: src/components/read-more.tsx:10
+msgid "Want to know more?"
+msgstr ""
+
+#: src/pages/404.tsx:8
+msgid "You just found a page that doesn't exist... the sadness."
 msgstr ""

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -13,6 +13,100 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/footer.tsx:79
+msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
+msgstr ""
+
+#: src/components/footer.tsx:80
+msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
+msgstr ""
+
+#: src/components/footer.tsx:35
 #: src/components/header.tsx:34
-msgid "ABOUT US"
-msgstr "SOBRE NOSOTROS"
+msgid "About us"
+msgstr "Sobre nosotros"
+
+#: src/components/footer.tsx:27
+#: src/components/header.tsx:58
+msgid "Contact"
+msgstr ""
+
+#: src/components/footer.tsx:30
+msgid "Donate"
+msgstr ""
+
+#: src/components/footer.tsx:57
+#: src/pages/contact-us.tsx:40
+msgid "Email Address"
+msgstr ""
+
+#: src/components/footer.tsx:43
+#: src/components/header.tsx:48
+msgid "Jobs"
+msgstr ""
+
+#: src/components/footer.tsx:52
+msgid "Join our mailing list!"
+msgstr ""
+
+#: src/components/header.tsx:54
+msgid "Mission"
+msgstr ""
+
+#: src/pages/404.tsx:7
+msgid "Not found"
+msgstr ""
+
+#: src/components/header.tsx:39
+msgid "Our Partners"
+msgstr ""
+
+#: src/components/header.tsx:42
+msgid "Our Team"
+msgstr ""
+
+#: src/components/footer.tsx:24
+msgid "Our mission"
+msgstr ""
+
+#: src/components/footer.tsx:40
+msgid "Our partners"
+msgstr ""
+
+#: src/components/footer.tsx:37
+msgid "Our team"
+msgstr ""
+
+#: src/components/footer.tsx:46
+#: src/components/header.tsx:45
+msgid "Press"
+msgstr ""
+
+#: src/components/footer.tsx:82
+msgid "Privacy policy"
+msgstr ""
+
+#: src/components/footer.tsx:21
+msgid "Products & Services"
+msgstr ""
+
+#: src/components/header.tsx:65
+#: src/components/header.tsx:72
+msgid "Sign in"
+msgstr ""
+
+#: src/components/footer.tsx:61
+msgid "Sign up"
+msgstr ""
+
+#: src/components/footer.tsx:85
+msgid "Terms of use"
+msgstr ""
+
+#: src/components/read-more.tsx:10
+msgid "Want to know more?"
+msgstr ""
+
+#: src/pages/404.tsx:8
+msgid "You just found a page that doesn't exist... the sadness."
+msgstr ""

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -6,7 +6,7 @@ const NotFoundPage = () => (
   <Layout metadata={{title:"Page Not Found"}}>
     <section className="hero is-large has-background-info">
       <div className="hero-body has-text-centered">
-        <h1 className="title has-text-danger"><Trans>NOT FOUND</Trans></h1>
+        <h1 className="title has-text-danger is-uppercase"><Trans>Not found</Trans></h1>
         <p className="subtitle has-text-white"><Trans>You just found a page that doesn&#39;t exist... the sadness.</Trans></p>
       </div>
     </section>

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
+import { Trans } from '@lingui/macro';
 import Layout from '../components/layout'
 
 const NotFoundPage = () => (
   <Layout metadata={{title:"Page Not Found"}}>
     <section className="hero is-large has-background-info">
       <div className="hero-body has-text-centered">
-        <h1 className="title has-text-danger">NOT FOUND</h1>
-        <p className="subtitle has-text-white">You just found a page that doesn&#39;t exist... the sadness.</p>
+        <h1 className="title has-text-danger"><Trans>NOT FOUND</Trans></h1>
+        <p className="subtitle has-text-white"><Trans>You just found a page that doesn&#39;t exist... the sadness.</Trans></p>
       </div>
     </section>
     

--- a/src/pages/contact-us.tsx
+++ b/src/pages/contact-us.tsx
@@ -3,7 +3,7 @@ import { StaticQuery, graphql } from 'gatsby'
 import { SocialIcon } from 'react-social-icons';
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { t } from '@lingui/macro';
-import { withI18n, withI18nProps } from '@lingui/react';
+import { I18n } from '@lingui/react';
 // import { Link } from 'gatsby'
 
 import '../styles/contact.scss' 
@@ -13,8 +13,9 @@ import { ContentfulContent } from '.'
 
 const MAILCHIMP_URL = "https://nyc.us13.list-manage.com/subscribe/post?u=d4f5d1addd4357eb77c3f8a99&amp;id=588f6c6ef4";
 
-export const ContactPageScaffolding = withI18n()((props: ContentfulContent & withI18nProps) => 
+export const ContactPageScaffolding = (props: ContentfulContent) => 
   (<Layout metadata={props.content.metadata} locale={props.locale}>
+    <I18n>{({i18n}) => 
     <div id="contact" className="contact-page" >
 
       <section className="hero is-medium is-white">
@@ -45,7 +46,7 @@ export const ContactPageScaffolding = withI18n()((props: ContentfulContent & wit
               <div className="mc-field-group">
                 <div className="field has-addons">
                     <div className="control is-expanded">
-                        <input type="email" name="EMAIL" className="required email input" id="mce-EMAIL" placeholder={props.i18n._(t`Email Address`)} />
+                        <input type="email" name="EMAIL" className="required email input" id="mce-EMAIL" placeholder={i18n._(t`Email Address`)} />
                     </div>
                     <div className="control">
                         <button className="button is-primary" type="submit">
@@ -62,7 +63,8 @@ export const ContactPageScaffolding = withI18n()((props: ContentfulContent & wit
       </section>
       
     </div>
-  </Layout>)); 
+    }</I18n>
+  </Layout>); 
 
 const ContactPage  = () => (
 <StaticQuery

--- a/src/pages/contact-us.tsx
+++ b/src/pages/contact-us.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { StaticQuery, graphql } from 'gatsby'
 import { SocialIcon } from 'react-social-icons';
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
+import { t } from '@lingui/macro';
+import { withI18n, withI18nProps } from '@lingui/react';
 // import { Link } from 'gatsby'
 
 import '../styles/contact.scss' 
@@ -11,7 +13,7 @@ import { ContentfulContent } from '.'
 
 const MAILCHIMP_URL = "https://nyc.us13.list-manage.com/subscribe/post?u=d4f5d1addd4357eb77c3f8a99&amp;id=588f6c6ef4";
 
-export const ContactPageScaffolding = (props: ContentfulContent) => 
+export const ContactPageScaffolding = withI18n()((props: ContentfulContent & withI18nProps) => 
   (<Layout metadata={props.content.metadata} locale={props.locale}>
     <div id="contact" className="contact-page" >
 
@@ -43,7 +45,7 @@ export const ContactPageScaffolding = (props: ContentfulContent) =>
               <div className="mc-field-group">
                 <div className="field has-addons">
                     <div className="control is-expanded">
-                        <input type="email" name="EMAIL" className="required email input" id="mce-EMAIL" placeholder="Email Address" />
+                        <input type="email" name="EMAIL" className="required email input" id="mce-EMAIL" placeholder={props.i18n._(t`Email Address`)} />
                     </div>
                     <div className="control">
                         <button className="button is-primary" type="submit">
@@ -60,7 +62,7 @@ export const ContactPageScaffolding = (props: ContentfulContent) =>
       </section>
       
     </div>
-  </Layout>); 
+  </Layout>)); 
 
 const ContactPage  = () => (
 <StaticQuery


### PR DESCRIPTION
This adds `<Trans>` tags and other such things around all non-Contentful text on the website.

## To do

- [x] Internationalize `placeholder` attributes on form fields.
- [ ] Internationalize `alt` attributes on images except WAIT WUT we don't have any?!  We should at least set `alt=""` on decorative images if we don't want them announced by screen readers, otherwise we should set them to something sensible pal.
- [x] Consider not upper-casing text that we happen to display in uppercase, and using [Bulma's `.is-uppercase`](https://bulma.io/documentation/modifiers/typography-helpers/#text-transformation) instead.  This decouples the styling of our text from localization, so e.g. if we ever decide to not uppercase the text, we won't have to re-translate the text.
- [x] Rebuild i18n catalogs.
