### PR TITLE
added demo site label and env var

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -37,3 +37,9 @@ GATSBY_ENABLE_ALGOLIA_ANALYTICS=
 ## The gatsby-plugin-canonical-urls plugin uses this variable to generate canonical url link tags for each page
 
 SITE_URL=
+
+## DEMO SITE (Optional)
+## 
+## Setting DEMO SITE to 1 will add a "Demo Site" label to the header.
+
+GATSBY_DEMO_SITE=

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,6 +5,8 @@ import { Trans } from '@lingui/macro';
 import '../styles/header.scss' 
 import { Locale } from '../pages';
 
+const isDemoSite = process.env.GATSBY_DEMO_SITE === '1';
+
 type Props = {
   isLandingPage?: boolean,
 } & Locale 
@@ -34,7 +36,11 @@ render() {
       <Link to={localePrefix + "/"} className="navbar-item">
         <img src={require("../img/brand/logo.png")} width="112" height="28" alt="JustFix.nyc" />
       </Link>
-
+      {isDemoSite && 
+        <div className="navbar-item">
+          <span className="tag is-warning"><Trans>DEMO SITE</Trans></span>
+        </div>
+      }
       <a role="button" className={"navbar-burger burger " + (this.state.burgerMenuIsOpen && "is-active") } aria-label="menu" aria-expanded="false" 
         onClick = {this.toggleBurgerMenu} data-target="navbar">
         <span aria-hidden="true"></span>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -22,7 +22,7 @@ msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr ""
 
 #: src/components/footer.tsx:35
-#: src/components/header.tsx:34
+#: src/components/header.tsx:38
 msgid "About us"
 msgstr ""
 
@@ -35,12 +35,16 @@ msgid "Back to top"
 msgstr ""
 
 #: src/components/footer.tsx:46
-#: src/components/header.tsx:65
+#: src/components/header.tsx:69
 msgid "Contact"
 msgstr ""
 
 #: src/pages/our-mission.tsx:21
 msgid "Contact Us"
+msgstr ""
+
+#: src/components/header.tsx:23
+msgid "DEMO SITE"
 msgstr ""
 
 #: src/components/footer.tsx:49
@@ -60,7 +64,7 @@ msgid "Enter your address to learn more."
 msgstr ""
 
 #: src/components/footer.tsx:43
-#: src/components/header.tsx:51
+#: src/components/header.tsx:55
 msgid "Jobs"
 msgstr ""
 
@@ -69,12 +73,12 @@ msgid "Join our mailing list!"
 msgstr ""
 
 #: src/components/footer.tsx:24
-#: src/components/header.tsx:61
+#: src/components/header.tsx:65
 msgid "Learn"
 msgstr ""
 
 #: src/components/footer.tsx:27
-#: src/components/header.tsx:39
+#: src/components/header.tsx:43
 msgid "Mission"
 msgstr ""
 
@@ -107,12 +111,12 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/footer.tsx:40
-#: src/components/header.tsx:45
+#: src/components/header.tsx:49
 msgid "Partners"
 msgstr ""
 
 #: src/components/footer.tsx:30
-#: src/components/header.tsx:48
+#: src/components/header.tsx:52
 msgid "Press"
 msgstr ""
 
@@ -121,7 +125,7 @@ msgid "Privacy policy"
 msgstr ""
 
 #: src/components/footer.tsx:21
-#: src/components/header.tsx:57
+#: src/components/header.tsx:61
 msgid "Products"
 msgstr ""
 
@@ -142,8 +146,8 @@ msgstr ""
 msgid "Search articles..."
 msgstr ""
 
-#: src/components/header.tsx:72
-#: src/components/header.tsx:79
+#: src/components/header.tsx:76
+#: src/components/header.tsx:83
 msgid "Sign in"
 msgstr ""
 
@@ -153,7 +157,7 @@ msgid "Sign up"
 msgstr ""
 
 #: src/components/footer.tsx:37
-#: src/components/header.tsx:42
+#: src/components/header.tsx:46
 msgid "Team"
 msgstr ""
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -25,7 +25,7 @@ msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr "<0>JustFix.nyc</0> es una organización sin fines de lucro registrada."
 
 #: src/components/footer.tsx:35
-#: src/components/header.tsx:34
+#: src/components/header.tsx:38
 msgid "About us"
 msgstr "Sobre nosotros"
 
@@ -38,13 +38,17 @@ msgid "Back to top"
 msgstr "Volver a Inicio"
 
 #: src/components/footer.tsx:46
-#: src/components/header.tsx:65
+#: src/components/header.tsx:69
 msgid "Contact"
 msgstr "Contacto"
 
 #: src/pages/our-mission.tsx:21
 msgid "Contact Us"
 msgstr "Contáctenos"
+
+#: src/components/header.tsx:23
+msgid "DEMO SITE"
+msgstr ""
 
 #: src/components/footer.tsx:49
 #: src/pages/our-mission.tsx:23
@@ -63,7 +67,7 @@ msgid "Enter your address to learn more."
 msgstr "Introduzca su dirección para empezar."
 
 #: src/components/footer.tsx:43
-#: src/components/header.tsx:51
+#: src/components/header.tsx:55
 msgid "Jobs"
 msgstr "Empleos"
 
@@ -72,12 +76,12 @@ msgid "Join our mailing list!"
 msgstr "¡Únete a nuestra lista de correo!"
 
 #: src/components/footer.tsx:24
-#: src/components/header.tsx:61
+#: src/components/header.tsx:65
 msgid "Learn"
 msgstr "Aprender"
 
 #: src/components/footer.tsx:27
-#: src/components/header.tsx:39
+#: src/components/header.tsx:43
 msgid "Mission"
 msgstr "Misión"
 
@@ -110,12 +114,12 @@ msgstr "No encontrado"
 #~ msgstr ""
 
 #: src/components/footer.tsx:40
-#: src/components/header.tsx:45
+#: src/components/header.tsx:49
 msgid "Partners"
 msgstr "Compañeros"
 
 #: src/components/footer.tsx:30
-#: src/components/header.tsx:48
+#: src/components/header.tsx:52
 msgid "Press"
 msgstr "Prensa"
 
@@ -124,7 +128,7 @@ msgid "Privacy policy"
 msgstr "Política de privacidad"
 
 #: src/components/footer.tsx:21
-#: src/components/header.tsx:57
+#: src/components/header.tsx:61
 msgid "Products"
 msgstr "Productos"
 
@@ -145,8 +149,8 @@ msgstr "Buscar dirección"
 msgid "Search articles..."
 msgstr "Buscar artículos..."
 
-#: src/components/header.tsx:72
-#: src/components/header.tsx:79
+#: src/components/header.tsx:76
+#: src/components/header.tsx:83
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
@@ -156,7 +160,7 @@ msgid "Sign up"
 msgstr "Registrarse"
 
 #: src/components/footer.tsx:37
-#: src/components/header.tsx:42
+#: src/components/header.tsx:46
 msgid "Team"
 msgstr "Equipo"
 
@@ -183,4 +187,3 @@ msgstr "Escrita por"
 #: src/pages/404.tsx:8
 msgid "You just found a page that doesn't exist... the sadness."
 msgstr "Acaba de llegar a una ruta que no existe... es muy triste."
-

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -28,4 +28,8 @@
     .button {
         min-width: 120px;
     }
+    .tag.is-warning {
+        border-radius: 0;
+        transform: rotate(-4deg);
+    }
 }


### PR DESCRIPTION
This PR adds a small label to the header of the org site, enabled by an ENV variable, that indicates if the site is our demo/preview site. I copied the same styling from the Tenant Platform.