### PR TITLE
made all tenant app links on demo site go to demo.justfix

### DIFF
--- a/src/components/ddo-searchbar.tsx
+++ b/src/components/ddo-searchbar.tsx
@@ -3,7 +3,7 @@ import { GeoAutocomplete, GeoAutocompleteItem, GeoAutocompleteProps } from "./ge
 import classnames from 'classnames';
 
 /** The URL for Data-Driven Onboarding (DDO) on the JustFix Tenant Platform. */
-const DDO_URL = "https://app.justfix.nyc/ddo";
+const DDO_URL = 'https://' + ((process.env.GATSBY_DEMO_SITE === '1') ? 'demo' : 'app') + '.justfix.nyc/ddo'
 
 /** The querystring variable used to communicate the address for DDO. */
 const DDO_ADDRESS_VAR = "address";

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -7,6 +7,8 @@ import { Locale } from '../pages';
 
 const isDemoSite = process.env.GATSBY_DEMO_SITE === '1';
 
+const TENANT_PLATFORM_URL = 'https://' + (isDemoSite ? 'demo' : 'app') + '.justfix.nyc/login';
+
 type Props = {
   isLandingPage?: boolean,
 } & Locale 
@@ -94,14 +96,14 @@ render() {
         </Link> */}
 
         {this.state.burgerMenuIsOpen && 
-        <a className="navbar-item has-text-black is-uppercase" href="https://app.justfix.nyc/login">
+        <a className="navbar-item has-text-black is-uppercase" href={TENANT_PLATFORM_URL}>
           <Trans>Sign in</Trans>
         </a>}
 
       </div>
         <div className="navbar-item">
           <div className="buttons">
-            <a className="button is-primary is-uppercase is-inverted is-outlined" href="https://app.justfix.nyc/login">
+            <a className="button is-primary is-uppercase is-inverted is-outlined" href={TENANT_PLATFORM_URL}>
               <Trans>Sign in</Trans>
             </a>
         </div>


### PR DESCRIPTION
I made any hard-coded link to the tenant app go do `demo.justfix.nyc` when on the DEMO org site and `app.justfix.nyc` otherwise. Unfortunately, any links to the tenant app that we have in our Contentful space (like the links in the #products section, or in a Learning Center article) are not dynamic.