### PR TITLE
Add a changelog

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@babel/core": "^7.6.4",
     "@contentful/rich-text-plain-text-renderer": "^13.4.0",
     "@contentful/rich-text-react-renderer": "^13.4.0",
+    "@contentful/rich-text-types": "^14.1.0",
     "@justfixnyc/geosearch-requester": "^0.0.6",
     "@lingui/react": "^2.8.3",
     "@types/classnames": "^2.2.9",

--- a/src/components/embedded-asset-node.tsx
+++ b/src/components/embedded-asset-node.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { NodeData } from "@contentful/rich-text-types";
+
+const IMAGE_CONTENT_TYPE_RE = /^image\//;
+
+const DEFAULT_LOCALE = 'en-US';
+
+/**
+ * A data type mapped by different locales, so that e.g.
+ * 'en-US' might have one value of the data type, while
+ * 'es' might have another.
+ */
+type LocaleMapped<T> = {
+  [locale: string]: T|undefined,
+};
+
+/**
+ * Part of Contentful's rich text node, describing file metadata about an
+ * embedded asset.
+ */
+type FileInfo = {
+  url: string,
+  details: {
+    size: number,
+    image: {
+      width: number,
+      height: number,
+    },
+  },
+  fileName: string,
+  contentType: string,
+};
+
+/**
+ * A Contentful rich text node describing an embedded assset.
+ * 
+ * I'm not sure why this isn't already defined by @contentful/rich-text-types...
+ */
+export type EmbeddedAssetNode = {
+  data: NodeData & {
+    target?: {
+      fields: {
+        title: LocaleMapped<string>,
+        description: LocaleMapped<string>,
+        file: LocaleMapped<FileInfo>,
+      }
+    }
+  }
+};
+
+/**
+ * Renders an embedded asset in Contentful rich text.
+ * 
+ * This ought to be supported out-of-the-box by Contentful's rich text package,
+ * but it's not at the time of this writing: https://github.com/contentful/rich-text/issues/61
+ */
+export const EmbeddedAsset: React.FC<{
+  node: EmbeddedAssetNode,
+  locale: string,
+  className?: string,
+}> = ({node, locale, className}) => {
+  if (!node.data.target) {
+    throw new Error('No "target" on embedded asset node!');
+  }
+  const { fields } = node.data.target;
+  const altText = fields.description[locale] || fields.description[DEFAULT_LOCALE] || '';
+  const file = fields.file[locale] || fields.file[DEFAULT_LOCALE];
+  if (!file) {
+    throw new Error('No file information on embedded asset node!');
+  }
+  if (!IMAGE_CONTENT_TYPE_RE.test(file.contentType)) {
+    throw new Error(`Unsupported embedded asset content type: ${file.contentType}`);
+  }
+
+  return <img src={file.url} className={className} width={file.details.image.width} height={file.details.image.height} alt={altText} />;
+};

--- a/src/pages/changes.es.tsx
+++ b/src/pages/changes.es.tsx
@@ -5,7 +5,7 @@ import { ChangelogPageScaffolding } from './changes';
 const SpanishChangelogPage: React.FC<{}> = () => (
   <StaticQuery query={graphql`
   query ($locale: String! = "es") { ...LocalizedChangelogEntries }
-  `} render={data => (<ChangelogPageScaffolding entries={data} />)} />
+  `} render={data => (<ChangelogPageScaffolding content={data} />)} />
 );
 
 export default SpanishChangelogPage;

--- a/src/pages/changes.es.tsx
+++ b/src/pages/changes.es.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { StaticQuery, graphql } from 'gatsby';
+import { Changelog } from './changes';
+
+const SpanishChangelogPage: React.FC<{}> = () => (
+  <StaticQuery query={graphql`
+  query ($locale: String! = "es") { ...LocalizedChangelogEntries }
+  `} render={data => (<Changelog entries={data} />)} />
+);
+
+export default SpanishChangelogPage;

--- a/src/pages/changes.es.tsx
+++ b/src/pages/changes.es.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { StaticQuery, graphql } from 'gatsby';
-import { Changelog } from './changes';
+import { ChangelogPageScaffolding } from './changes';
 
 const SpanishChangelogPage: React.FC<{}> = () => (
   <StaticQuery query={graphql`
   query ($locale: String! = "es") { ...LocalizedChangelogEntries }
-  `} render={data => (<Changelog entries={data} />)} />
+  `} render={data => (<ChangelogPageScaffolding entries={data} />)} />
 );
 
 export default SpanishChangelogPage;

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -49,7 +49,7 @@ const ChangelogEntry: React.FC<{node: ChangelogEntry, prevNode?: ChangelogEntry}
   </>;
 };
 
-export const Changelog: React.FC<{entries: ChangelogEntries}> = ({entries}) => {
+export const ChangelogPageScaffolding: React.FC<{entries: ChangelogEntries}> = ({entries}) => {
   const { nodes } = entries.allContentfulChangelogEntry;
 
   return (
@@ -100,7 +100,7 @@ fragment LocalizedChangelogEntries on Query {
 const EnglishChangelogPage: React.FC<{}> = () => (
   <StaticQuery query={graphql`
   query ($locale: String! = "en-US") { ...LocalizedChangelogEntries }
-  `} render={data => (<Changelog entries={data} />)} />
+  `} render={data => (<ChangelogPageScaffolding entries={data} />)} />
 );
 
 export default EnglishChangelogPage;

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -79,7 +79,7 @@ export const ChangelogPageScaffolding: React.FC<{content: ChangelogEntries}> = (
   );
 };
 
-export const LocalizedChangelogEntries = graphql`
+export const LocalizedChangelogEntriesFragment = graphql`
 fragment LocalizedChangelogEntries on Query {
   allContentfulChangelogEntry(
     filter: {node_locale: {eq: $locale}},

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import Layout from '../components/layout';
+import { StaticQuery, graphql } from 'gatsby';
+import { Document } from '@contentful/rich-text-types';
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+
+import '../styles/changes.scss';
+
+type ChangelogEntry = {
+  title: string,
+  date: string, // e.g. "2019-10-01"
+  body: {
+    json: Document,
+  },
+  node_locale: string,
+};
+
+type YearAndMonth = {year: number, month: number};
+
+/**
+ * Given a date string in the form "YYYY-MM-DD", returns the "YYYY-MM" part.
+ */
+const isSameYearAndMonth = (a: YearAndMonth, b: YearAndMonth) => a.year === b.year && a.month === b.month;
+
+const parseYearAndMonth = (date: string): YearAndMonth => {
+  const year = parseInt(date.slice(0, 4), 10);
+  const month = parseInt(date.slice(5, 7), 10);
+
+  return {year, month};
+};
+
+const MONTHS = {
+  1: 'January',
+  2: 'February',
+  3: 'March',
+  4: 'April',
+  5: 'May',
+  6: 'June',
+  7: 'July',
+  8: 'August',
+  9: 'September',
+  10: 'October',
+  11: 'November',
+  12: 'December',
+};
+
+const ChangelogEntry: React.FC<{node: ChangelogEntry, prevNode?: ChangelogEntry}> = ({node, prevNode}) => {
+  const currYM = parseYearAndMonth(node.date);
+  const prevYM = prevNode ? parseYearAndMonth(prevNode.date) : undefined;
+  const showYM = !prevYM || !isSameYearAndMonth(currYM, prevYM);
+
+  return <>
+    {showYM && <h2 className="date-and-month">{MONTHS[currYM.month]} {currYM.year}</h2>}
+    <h3>{node.title}</h3>
+    {documentToReactComponents(node.body.json)}
+  </>;
+};
+
+const Changelog: React.FC<{nodes: ChangelogEntry[]}> = ({nodes}) => {
+  return (
+    <Layout>
+      <div className="changes-page">
+        <section className="hero is-small">
+          <div className="hero-body has-text-centered is-horizontal-center">
+            <div className="container">
+              <h1 className="title is-size-2 has-text-grey-dark has-text-weight-normal is-spaced">
+                Changelog
+              </h1>
+              <div className="subtitle has-text-grey-dark is-italic">
+                Learn what's new in JustFix.nyc's products
+              </div>
+            </div>
+          </div>
+          <div className="hero-body is-horizontal-center">
+            <div className="content has-text-grey-dark">
+            {nodes.map((node, i) => (
+              <ChangelogEntry node={node} prevNode={i > 0 ? nodes[i - 1] : undefined} />
+            ))}
+            </div>
+          </div>
+        </section>
+      </div>
+    </Layout>
+  );
+};
+
+const ChangelogPage: React.FC<{}> = () => (
+  <StaticQuery query={graphql`
+  {
+    allContentfulChangelogEntry(
+      filter: {node_locale: {eq: "en-US"}},
+      sort: {order: DESC, fields: [date, title]}
+    ) {
+      nodes {
+        title
+        date
+        body {
+          json
+        }
+        node_locale
+      }
+    }
+  }  
+  `} render={data => (<Changelog nodes={data.allContentfulChangelogEntry.nodes} />)} />
+);
+
+export default ChangelogPage;

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import Layout from '../components/layout';
 import { StaticQuery, graphql } from 'gatsby';
-import { Document } from '@contentful/rich-text-types';
+import { Document, BLOCKS } from '@contentful/rich-text-types';
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+import { EmbeddedAsset } from '../components/embedded-asset-node';
 
 import '../styles/changes.scss';
 
@@ -45,7 +46,11 @@ const ChangelogEntry: React.FC<{node: ChangelogEntry, prevNode?: ChangelogEntry}
   return <>
     {showYM && <h2 className="date-and-month">{currYM.localeString}</h2>}
     <h3>{node.title}</h3>
-    {documentToReactComponents(node.body.json)}
+    {documentToReactComponents(node.body.json, {
+      renderNode: {
+        [BLOCKS.EMBEDDED_ASSET]: (eaNode) => <EmbeddedAsset node={eaNode} locale={node.node_locale} className="block-quoted" />
+      }
+    })}
   </>;
 };
 
@@ -69,7 +74,7 @@ export const ChangelogPageScaffolding: React.FC<{content: ChangelogEntries}> = (
           <div className="hero-body is-horizontal-center content-wrapper tight">
             <div className="content has-text-grey-dark">
             {nodes.map((node, i) => (
-              <ChangelogEntry node={node} prevNode={i > 0 ? nodes[i - 1] : undefined} />
+              <ChangelogEntry key={i} node={node} prevNode={i > 0 ? nodes[i - 1] : undefined} />
             ))}
             </div>
           </div>

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -56,7 +56,7 @@ export const ChangelogPageScaffolding: React.FC<{content: ChangelogEntries}> = (
     <Layout>
       <div className="changes-page">
         <section className="hero is-small">
-          <div className="hero-body has-text-centered is-horizontal-center">
+          <div className="hero-body has-text-centered is-horizontal-center content-wrapper tight">
             <div className="container">
               <h1 className="title is-size-2 has-text-grey-dark has-text-weight-normal is-spaced">
                 Changelog
@@ -66,7 +66,7 @@ export const ChangelogPageScaffolding: React.FC<{content: ChangelogEntries}> = (
               </div>
             </div>
           </div>
-          <div className="hero-body is-horizontal-center">
+          <div className="hero-body is-horizontal-center content-wrapper tight">
             <div className="content has-text-grey-dark">
             {nodes.map((node, i) => (
               <ChangelogEntry node={node} prevNode={i > 0 ? nodes[i - 1] : undefined} />

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -6,6 +6,12 @@ import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 
 import '../styles/changes.scss';
 
+type ChangelogEntries = {
+  allContentfulChangelogEntry: {
+    nodes: ChangelogEntry[],
+  }
+};
+
 type ChangelogEntry = {
   title: string,
   date: string, // e.g. "2019-10-01"
@@ -43,7 +49,9 @@ const ChangelogEntry: React.FC<{node: ChangelogEntry, prevNode?: ChangelogEntry}
   </>;
 };
 
-const Changelog: React.FC<{nodes: ChangelogEntry[]}> = ({nodes}) => {
+export const Changelog: React.FC<{entries: ChangelogEntries}> = ({entries}) => {
+  const { nodes } = entries.allContentfulChangelogEntry;
+
   return (
     <Layout>
       <div className="changes-page">
@@ -71,24 +79,28 @@ const Changelog: React.FC<{nodes: ChangelogEntry[]}> = ({nodes}) => {
   );
 };
 
-const ChangelogPage: React.FC<{}> = () => (
-  <StaticQuery query={graphql`
-  {
-    allContentfulChangelogEntry(
-      filter: {node_locale: {eq: "en-US"}},
-      sort: {order: DESC, fields: [date, title]}
-    ) {
-      nodes {
-        title
-        date
-        body {
-          json
-        }
-        node_locale
+export const LocalizedChangelogEntries = graphql`
+fragment LocalizedChangelogEntries on Query {
+  allContentfulChangelogEntry(
+    filter: {node_locale: {eq: $locale}},
+    sort: {order: DESC, fields: [date, title]}
+  ) {
+    nodes {
+      title
+      date
+      body {
+        json
       }
+      node_locale
     }
-  }  
-  `} render={data => (<Changelog nodes={data.allContentfulChangelogEntry.nodes} />)} />
+  }
+}
+`;
+
+const EnglishChangelogPage: React.FC<{}> = () => (
+  <StaticQuery query={graphql`
+  query ($locale: String! = "en-US") { ...LocalizedChangelogEntries }
+  `} render={data => (<Changelog entries={data} />)} />
 );
 
-export default ChangelogPage;
+export default EnglishChangelogPage;

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -49,8 +49,8 @@ const ChangelogEntry: React.FC<{node: ChangelogEntry, prevNode?: ChangelogEntry}
   </>;
 };
 
-export const ChangelogPageScaffolding: React.FC<{entries: ChangelogEntries}> = ({entries}) => {
-  const { nodes } = entries.allContentfulChangelogEntry;
+export const ChangelogPageScaffolding: React.FC<{content: ChangelogEntries}> = ({content}) => {
+  const { nodes } = content.allContentfulChangelogEntry;
 
   return (
     <Layout>
@@ -100,7 +100,7 @@ fragment LocalizedChangelogEntries on Query {
 const EnglishChangelogPage: React.FC<{}> = () => (
   <StaticQuery query={graphql`
   query ($locale: String! = "en-US") { ...LocalizedChangelogEntries }
-  `} render={data => (<ChangelogPageScaffolding entries={data} />)} />
+  `} render={data => (<ChangelogPageScaffolding content={data} />)} />
 );
 
 export default EnglishChangelogPage;

--- a/src/pages/changes.tsx
+++ b/src/pages/changes.tsx
@@ -15,42 +15,29 @@ type ChangelogEntry = {
   node_locale: string,
 };
 
-type YearAndMonth = {year: number, month: number};
+type YearAndMonth = {year: number, month: number, localeString: string};
 
 /**
  * Given a date string in the form "YYYY-MM-DD", returns the "YYYY-MM" part.
  */
 const isSameYearAndMonth = (a: YearAndMonth, b: YearAndMonth) => a.year === b.year && a.month === b.month;
 
-const parseYearAndMonth = (date: string): YearAndMonth => {
+const parseYearAndMonth = (date: string, locale: string): YearAndMonth => {
   const year = parseInt(date.slice(0, 4), 10);
   const month = parseInt(date.slice(5, 7), 10);
+  const dateObj = new Date(year, month - 1);
+  const localeString = dateObj.toLocaleString(locale, {month: 'long', year: 'numeric'});
 
-  return {year, month};
-};
-
-const MONTHS = {
-  1: 'January',
-  2: 'February',
-  3: 'March',
-  4: 'April',
-  5: 'May',
-  6: 'June',
-  7: 'July',
-  8: 'August',
-  9: 'September',
-  10: 'October',
-  11: 'November',
-  12: 'December',
+  return {year, month, localeString};
 };
 
 const ChangelogEntry: React.FC<{node: ChangelogEntry, prevNode?: ChangelogEntry}> = ({node, prevNode}) => {
-  const currYM = parseYearAndMonth(node.date);
-  const prevYM = prevNode ? parseYearAndMonth(prevNode.date) : undefined;
+  const currYM = parseYearAndMonth(node.date, node.node_locale);
+  const prevYM = prevNode ? parseYearAndMonth(prevNode.date, prevNode.node_locale) : undefined;
   const showYM = !prevYM || !isSameYearAndMonth(currYM, prevYM);
 
   return <>
-    {showYM && <h2 className="date-and-month">{MONTHS[currYM.month]} {currYM.year}</h2>}
+    {showYM && <h2 className="date-and-month">{currYM.localeString}</h2>}
     <h3>{node.title}</h3>
     {documentToReactComponents(node.body.json)}
   </>;

--- a/src/styles/changes.scss
+++ b/src/styles/changes.scss
@@ -4,4 +4,14 @@
         padding-bottom: 16px;
         border-bottom: 1px solid lightgray;
     }
+
+    img.block-quoted {
+        border-left: 0.25em solid #dfe2e5;
+        padding: 0 1em;
+        display: block;
+    }
+
+    img.block-quoted:not(:last-child) {
+        margin-bottom: 1em;
+    }
 }

--- a/src/styles/changes.scss
+++ b/src/styles/changes.scss
@@ -1,0 +1,11 @@
+.changes-page {
+    .content h2.date-and-month {
+        margin-top: 2em;
+        padding-bottom: 16px;
+        border-bottom: 1px solid lightgray;
+    }
+
+    .hero-body {
+        max-width: 720px;
+    }
+}

--- a/src/styles/changes.scss
+++ b/src/styles/changes.scss
@@ -4,8 +4,4 @@
         padding-bottom: 16px;
         border-bottom: 1px solid lightgray;
     }
-
-    .hero-body {
-        max-width: 720px;
-    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1800,6 +1800,11 @@
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-13.4.0.tgz#a59c311ebd1b801ee00edbc08663c8d78da26171"
   integrity sha512-YPdYqGmWiGAood7ri2BUXfPQKNthkQYV1rmQdaq4UAxWK5NLB5NXckaUYLbohqhHKtrq4tnfzVn+ePWID7Dzbg==
 
+"@contentful/rich-text-types@^14.1.0":
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-14.1.0.tgz#e76938005e59fafb5da353646393fcd354ed4d64"
+  integrity sha512-dqb9U+eMthGl8wJhOM5PGV0MOLxFNMJjMgVU600uHJ4Z4u39iXpdFR1VXbaownuvhJyR+9V+VLEFXNZJ1veGZg==
+
 "@emotion/babel-utils@^0.6.4":
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"


### PR DESCRIPTION
This adds a changelog at `/changes` that is roughly based on the [Slack changelog](https://slack.com/help/articles/115004846068-Slack-updates-and-changes): there's a heading for each year and month (e.g. "October 2019") that has at least one change in it, and each individual change is listed with its own sub-heading title (e.g. "HP Action now in beta").  The entries are sorted reverse-chronologically.  When two entries happen to occur on the same date, they're sorted alphabetically.

The following changelog content is just filler to show the general layout:

> ![image](https://user-images.githubusercontent.com/124687/76087172-9dbd3a00-5f83-11ea-9e41-720e190deb8f.png)

This is what the content model looks like on the Contentful side:

> ![image](https://user-images.githubusercontent.com/124687/76087249-c5ac9d80-5f83-11ea-8dfb-f148598a205c.png)
