### PR TITLE
Refactored localized graphql queries

### DIFF
--- a/src/pages/about/partners.es.tsx
+++ b/src/pages/about/partners.es.tsx
@@ -5,55 +5,9 @@ import { PartnersPageScaffolding } from './partners';
 
 const PartnersPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulPartnersPage( node_locale: { eq: "es" } ) {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          subtitle {
-            subtitle
-          }
-          partnerOrganizations {
-            name
-            link
-            logo {
-              fluid {
-                src
-              }
-            }
-          }
-          fundersTitle 
-          funders {
-            name
-            link
-            logo {
-              fluid {
-                src
-              }
-            }
-          }
-          collaborationBanner {
-            title
-            subtitle
-          }
-          readMore {
-            title
-            link
-          }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...PartnersPageQuery }
+  `}
   render = {data => (<PartnersPageScaffolding content={data.contentfulPartnersPage} locale="es" />)}
   />
 );

--- a/src/pages/about/partners.es.tsx
+++ b/src/pages/about/partners.es.tsx
@@ -6,7 +6,7 @@ import { PartnersPageScaffolding } from './partners';
 const PartnersPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...PartnersPageQuery }
+    query ($locale: String! = "es") { ...PartnersPage }
   `}
   render = {data => (<PartnersPageScaffolding content={data.contentfulPartnersPage} locale="es" />)}
   />

--- a/src/pages/about/partners.tsx
+++ b/src/pages/about/partners.tsx
@@ -73,8 +73,8 @@ export const PartnersPageScaffolding = (props: ContentfulContent) =>
   </div>
 </Layout>); 
 
-export const PartnersPageQuery = graphql`
-  fragment PartnersPageQuery on Query {
+export const PartnersPageFragment = graphql`
+  fragment PartnersPage on Query {
     contentfulPartnersPage( node_locale: { eq: $locale } ) {
       metadata {
         title
@@ -125,7 +125,7 @@ export const PartnersPageQuery = graphql`
 const PartnersPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...PartnersPageQuery }
+    query ($locale: String! = "en-US") { ...PartnersPage }
   `}
   render = {data => (<PartnersPageScaffolding content={data.contentfulPartnersPage} />)}
   />

--- a/src/pages/about/partners.tsx
+++ b/src/pages/about/partners.tsx
@@ -73,58 +73,60 @@ export const PartnersPageScaffolding = (props: ContentfulContent) =>
   </div>
 </Layout>); 
 
-
-const PartnersPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulPartnersPage{
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          subtitle {
-            subtitle
-          }
-          partnerOrganizations {
-            name
-            link
-            logo {
-              fluid {
-                src
-              }
-            }
-          }
-          fundersTitle 
-          funders {
-            name
-            link
-            logo {
-              fluid {
-                src
-              }
-            }
-          }
-          collaborationBanner {
-            title
-            subtitle
-          }
-          readMore {
-            title
-            link
+export const PartnersPageQuery = graphql`
+  fragment PartnersPageQuery on Query {
+    contentfulPartnersPage( node_locale: { eq: $locale } ) {
+      metadata {
+        title
+        description
+        keywords { 
+          keywords 
+        }
+        shareImage {
+          file {
+            url
           }
         }
       }
-    `}
+      title
+      subtitle {
+        subtitle
+      }
+      partnerOrganizations {
+        name
+        link
+        logo {
+          fluid {
+            src
+          }
+        }
+      }
+      fundersTitle 
+      funders {
+        name
+        link
+        logo {
+          fluid {
+            src
+          }
+        }
+      }
+      collaborationBanner {
+        title
+        subtitle
+      }
+      readMore {
+        title
+        link
+      }
+    }
+  }`;
+
+const PartnersPage  = () => (
+<StaticQuery
+  query={graphql`
+    query ($locale: String! = "en-US") { ...PartnersPageQuery }
+  `}
   render = {data => (<PartnersPageScaffolding content={data.contentfulPartnersPage} />)}
   />
 );

--- a/src/pages/about/press.es.tsx
+++ b/src/pages/about/press.es.tsx
@@ -4,39 +4,9 @@ import { PressPageScaffolding } from './press';
 
 const PressPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulPressPage( node_locale: { eq: "es" } ) {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          pressItems {
-            title
-            hyperlink
-            linkText
-            logo {
-              file {
-                url
-              }
-            }
-          }
-          readMore {
-            title
-            link
-          }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...PressPageQuery }
+  `}
   render = {data => (<PressPageScaffolding content={data.contentfulPressPage} locale="es" />)}
   />
 );

--- a/src/pages/about/press.es.tsx
+++ b/src/pages/about/press.es.tsx
@@ -5,7 +5,7 @@ import { PressPageScaffolding } from './press';
 const PressPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...PressPageQuery }
+    query ($locale: String! = "es") { ...PressPage }
   `}
   render = {data => (<PressPageScaffolding content={data.contentfulPressPage} locale="es" />)}
   />

--- a/src/pages/about/press.tsx
+++ b/src/pages/about/press.tsx
@@ -55,8 +55,8 @@ export const PressPageScaffolding = (props: ContentfulContent) =>
 
 </Layout>); 
 
-export const PressPageQuery = graphql`
-  fragment PressPageQuery on Query {
+export const PressPageFragment = graphql`
+  fragment PressPage on Query {
     contentfulPressPage( node_locale: { eq: $locale } ) {
       metadata {
         title
@@ -91,7 +91,7 @@ export const PressPageQuery = graphql`
 const PressPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...PressPageQuery }
+    query ($locale: String! = "en-US") { ...PressPage }
   `}
   render = {data => (<PressPageScaffolding content={data.contentfulPressPage} />)}
   />

--- a/src/pages/about/press.tsx
+++ b/src/pages/about/press.tsx
@@ -55,42 +55,44 @@ export const PressPageScaffolding = (props: ContentfulContent) =>
 
 </Layout>); 
 
-
-const PressPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulPressPage {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          pressItems {
-            title
-            hyperlink
-            linkText
-            logo {
-              file {
-                url
-              }
-            }
-          }
-          readMore {
-            title
-            link
+export const PressPageQuery = graphql`
+  fragment PressPageQuery on Query {
+    contentfulPressPage( node_locale: { eq: $locale } ) {
+      metadata {
+        title
+        description
+        keywords { 
+          keywords 
+        }
+        shareImage {
+          file {
+            url
           }
         }
       }
-    `}
+      title
+      pressItems {
+        title
+        hyperlink
+        linkText
+        logo {
+          file {
+            url
+          }
+        }
+      }
+      readMore {
+        title
+        link
+      }
+    }
+  }`;
+
+const PressPage  = () => (
+<StaticQuery
+  query={graphql`
+    query ($locale: String! = "en-US") { ...PressPageQuery }
+  `}
   render = {data => (<PressPageScaffolding content={data.contentfulPressPage} />)}
   />
 );

--- a/src/pages/about/team.es.tsx
+++ b/src/pages/about/team.es.tsx
@@ -5,7 +5,7 @@ import { TeamPageScaffolding } from './team';
 const TeamPage  = () => (
 <StaticQuery  
   query={graphql`
-    query ($locale: String! = "es") { ...TeamPageQuery }
+    query ($locale: String! = "es") { ...TeamPage }
   `}
   render = {data => (<TeamPageScaffolding content={data.contentfulTeamPage} locale="es" />)}
   />

--- a/src/pages/about/team.es.tsx
+++ b/src/pages/about/team.es.tsx
@@ -3,63 +3,10 @@ import { StaticQuery, graphql } from 'gatsby'
 import { TeamPageScaffolding } from './team';
 
 const TeamPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulTeamPage( node_locale: { eq: "es" } ) {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          teamMembers {
-            name
-            title
-            description {
-              description
-            } 
-            photo {
-              fluid {
-                src
-              }
-            }
-            professionalLinks
-          }
-          directorsTitle 
-          directors {
-            name
-            title
-            photo {
-              file {
-                url
-              }
-            }
-            organization
-            organizationLink
-            description {
-              description
-            } 
-          }
-          otherContributorsTitle
-          otherContributors {
-            name
-            link
-          }
-          readMore {
-            title
-            link
-          }
-        }
-      }
-    `}
+<StaticQuery  
+  query={graphql`
+    query ($locale: String! = "es") { ...TeamPageQuery }
+  `}
   render = {data => (<TeamPageScaffolding content={data.contentfulTeamPage} locale="es" />)}
   />
 );

--- a/src/pages/about/team.tsx
+++ b/src/pages/about/team.tsx
@@ -120,8 +120,8 @@ export const TeamPageScaffolding = (props: ContentfulContent) =>
     
 </Layout>); 
 
-export const TeamPageQuery = graphql`
-  fragment TeamPageQuery on Query {
+export const TeamPageFragment = graphql`
+  fragment TeamPage on Query {
     contentfulTeamPage( node_locale: { eq: $locale } ) {
       metadata {
         title
@@ -179,7 +179,7 @@ export const TeamPageQuery = graphql`
 const TeamPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...TeamPageQuery }
+    query ($locale: String! = "en-US") { ...TeamPage }
   `}
   render = {data => (<TeamPageScaffolding content={data.contentfulTeamPage} />)}
   />

--- a/src/pages/about/team.tsx
+++ b/src/pages/about/team.tsx
@@ -120,65 +120,67 @@ export const TeamPageScaffolding = (props: ContentfulContent) =>
     
 </Layout>); 
 
-
-const TeamPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulTeamPage {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          teamMembers {
-            name
-            title
-            description {
-              description
-            } 
-            photo {
-              fluid {
-                src
-              }
-            }
-            professionalLinks
-          }
-          directorsTitle 
-          directors {
-            name
-            title
-            photo {
-              file {
-                url
-              }
-            }
-            organization
-            organizationLink
-            description {
-              description
-            } 
-          }
-          otherContributorsTitle
-          otherContributors {
-            name
-            link
-          }
-          readMore {
-            title
-            link
+export const TeamPageQuery = graphql`
+  fragment TeamPageQuery on Query {
+    contentfulTeamPage( node_locale: { eq: $locale } ) {
+      metadata {
+        title
+        description
+        keywords { 
+          keywords 
+        }
+        shareImage {
+          file {
+            url
           }
         }
       }
-    `}
+      title
+      teamMembers {
+        name
+        title
+        description {
+          description
+        } 
+        photo {
+          fluid {
+            src
+          }
+        }
+        professionalLinks
+      }
+      directorsTitle 
+      directors {
+        name
+        title
+        photo {
+          file {
+            url
+          }
+        }
+        organization
+        organizationLink
+        description {
+          description
+        } 
+      }
+      otherContributorsTitle
+      otherContributors {
+        name
+        link
+      }
+      readMore {
+        title
+        link
+      }
+    }
+  }`;
+
+const TeamPage  = () => (
+<StaticQuery
+  query={graphql`
+    query ($locale: String! = "en-US") { ...TeamPageQuery }
+  `}
   render = {data => (<TeamPageScaffolding content={data.contentfulTeamPage} />)}
   />
 );

--- a/src/pages/contact-us.es.tsx
+++ b/src/pages/contact-us.es.tsx
@@ -5,7 +5,7 @@ import { ContactPageScaffolding } from './contact-us';
 const ContactPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...ContactPageQuery }
+    query ($locale: String! = "es") { ...ContactPage }
   `}
   render = {data => (<ContactPageScaffolding content={data.contentfulContactPage} locale="es" />)}
   />

--- a/src/pages/contact-us.es.tsx
+++ b/src/pages/contact-us.es.tsx
@@ -4,34 +4,9 @@ import { ContactPageScaffolding } from './contact-us';
 
 const ContactPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulContactPage( node_locale: { eq: "es" } ) {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          pageTitle
-          contactCta {
-            json
-          }
-          socialButtons {
-            title
-            url
-          }
-          mailingListTitle 
-          mailingListSubtitle
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...ContactPageQuery }
+  `}
   render = {data => (<ContactPageScaffolding content={data.contentfulContactPage} locale="es" />)}
   />
 );

--- a/src/pages/contact-us.tsx
+++ b/src/pages/contact-us.tsx
@@ -66,8 +66,8 @@ export const ContactPageScaffolding = (props: ContentfulContent) =>
     }</I18n>
   </Layout>); 
 
-export const ContactPageQuery = graphql`
-  fragment ContactPageQuery on Query {
+export const ContactPageFragment = graphql`
+  fragment ContactPage on Query {
     contentfulContactPage( node_locale: { eq: $locale } ) {
       metadata {
         title
@@ -97,7 +97,7 @@ export const ContactPageQuery = graphql`
 const ContactPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...ContactPageQuery }
+    query ($locale: String! = "en-US") { ...ContactPage }
   `}
   render = {data => (<ContactPageScaffolding content={data.contentfulContactPage} />)}
   />

--- a/src/pages/contact-us.tsx
+++ b/src/pages/contact-us.tsx
@@ -66,36 +66,39 @@ export const ContactPageScaffolding = (props: ContentfulContent) =>
     }</I18n>
   </Layout>); 
 
-const ContactPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulContactPage {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          pageTitle
-          contactCta {
-            json
-          }
-          socialButtons {
-            title
+export const ContactPageQuery = graphql`
+  fragment ContactPageQuery on Query {
+    contentfulContactPage( node_locale: { eq: $locale } ) {
+      metadata {
+        title
+        description
+        keywords { 
+          keywords 
+        }
+        shareImage {
+          file {
             url
           }
-          mailingListTitle 
-          mailingListSubtitle
         }
       }
-    `}
+      pageTitle
+      contactCta {
+        json
+      }
+      socialButtons {
+        title
+        url
+      }
+      mailingListTitle 
+      mailingListSubtitle
+    }
+  }`;
+
+const ContactPage  = () => (
+<StaticQuery
+  query={graphql`
+    query ($locale: String! = "en-US") { ...ContactPageQuery }
+  `}
   render = {data => (<ContactPageScaffolding content={data.contentfulContactPage} />)}
   />
 );

--- a/src/pages/index.es.tsx
+++ b/src/pages/index.es.tsx
@@ -5,7 +5,7 @@ import { LandingPageScaffolding } from '.';
 const LandingPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...LandingPageQuery }
+    query ($locale: String! = "es") { ...LandingPage }
   `}
   render = {data => (<LandingPageScaffolding content={data.contentfulHomePage} locale="es" />)}
   />

--- a/src/pages/index.es.tsx
+++ b/src/pages/index.es.tsx
@@ -4,49 +4,9 @@ import { LandingPageScaffolding } from '.';
 
 const LandingPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulHomePage( node_locale: { eq: "es" } ) {
-          landingLeadInText
-          landingTextLoopText
-          landingFallbackText
-          landingFooterText
-          landingImage {
-            fluid {
-              ...GatsbyContentfulFluid
-            }
-          }
-          productSectionTitle
-          homePageProductBlocks {
-            title
-            description
-            button {
-              title
-              link
-            }
-            screenshot {
-              fluid {
-              ...GatsbyContentfulFluid
-              } 
-            }
-          }
-          rentHistory {
-            title
-            description {
-              json
-            }
-          }
-          pressTitle 
-          pressLogos {
-            logo {
-              file {
-                url
-              }
-            }
-          }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...LandingPageQuery }
+  `}
   render = {data => (<LandingPageScaffolding content={data.contentfulHomePage} locale="es" />)}
   />
 );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -188,53 +188,55 @@ export const LandingPageScaffolding = (props: ContentfulContent) =>
     </div>
 </Layout>); 
 
-
-const LandingPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulHomePage {
-          landingLeadInText
-          landingTextLoopText
-          landingFallbackText
-          landingFooterText
-          landingImage {
-            fluid {
-              ...GatsbyContentfulFluid
-            }
-          }
-          productSectionTitle
-          homePageProductBlocks {
-            title
-            description
-            button {
-              title
-              link
-            }
-            screenshot {
-              fluid {
-              ...GatsbyContentfulFluid
-              } 
-            }
-          }
-          rentHistory {
-            title
-            description {
-              json
-            }
-          }
-          pressTitle 
-          pressLogos {
-            title
-            logo {
-              file {
-                url
-              }
-            }
+export const LandingPageQuery = graphql`
+  fragment LandingPageQuery on Query {
+    contentfulHomePage( node_locale: { eq: $locale } ) {
+      landingLeadInText
+      landingTextLoopText
+      landingFallbackText
+      landingFooterText
+      landingImage {
+        fluid {
+          ...GatsbyContentfulFluid
+        }
+      }
+      productSectionTitle
+      homePageProductBlocks {
+        title
+        description
+        button {
+          title
+          link
+        }
+        screenshot {
+          fluid {
+          ...GatsbyContentfulFluid
+          } 
+        }
+      }
+      rentHistory {
+        title
+        description {
+          json
+        }
+      }
+      pressTitle 
+      pressLogos {
+        title
+        logo {
+          file {
+            url
           }
         }
       }
-    `}
+    }
+  }`;
+
+const LandingPage  = () => (
+<StaticQuery
+  query={graphql`
+    query ($locale: String! = "en-US") { ...LandingPageQuery }
+  `}
   render = {data => (<LandingPageScaffolding content={data.contentfulHomePage} />)}
   />
 );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -188,8 +188,8 @@ export const LandingPageScaffolding = (props: ContentfulContent) =>
     </div>
 </Layout>); 
 
-export const LandingPageQuery = graphql`
-  fragment LandingPageQuery on Query {
+export const LandingPageFragment = graphql`
+  fragment LandingPage on Query {
     contentfulHomePage( node_locale: { eq: $locale } ) {
       landingLeadInText
       landingTextLoopText
@@ -235,7 +235,7 @@ export const LandingPageQuery = graphql`
 const LandingPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...LandingPageQuery }
+    query ($locale: String! = "en-US") { ...LandingPage }
   `}
   render = {data => (<LandingPageScaffolding content={data.contentfulHomePage} />)}
   />

--- a/src/pages/learn.es.tsx
+++ b/src/pages/learn.es.tsx
@@ -5,7 +5,7 @@ import { LearningPageScaffolding } from './learn';
 const LearningPage  = () => (
   <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...LearningPageQuery }
+    query ($locale: String! = "es") { ...LearningPage }
   `}
   render = {data => (<LearningPageScaffolding content={data.contentfulLearningCenterSearchPage} locale="es" />)}
   />

--- a/src/pages/learn.es.tsx
+++ b/src/pages/learn.es.tsx
@@ -4,58 +4,9 @@ import { LearningPageScaffolding } from './learn';
 
 const LearningPage  = () => (
   <StaticQuery
-    query={graphql`
-      query {
-        contentfulLearningCenterSearchPage( node_locale: { eq: "es" } ) {
-          metadata {
-            title
-            description
-            keywords {
-              keywords
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          headerImage {
-            file {
-              url
-            }
-          }
-          subtitle
-          articles {
-            slug
-            title
-            previewText {
-              previewText
-            }
-            categories {
-              title
-              description
-              slug
-            }
-          }
-          learningCenterCta {
-            title
-            subtitle
-            ctaText
-            ctaLink
-          }
-          justFixCta {
-            title
-            subtitle
-            ctaText
-            ctaLink
-          }
-          thankYouText {
-            json
-          }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...LearningPageQuery }
+  `}
   render = {data => (<LearningPageScaffolding content={data.contentfulLearningCenterSearchPage} locale="es" />)}
   />
 );

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -84,8 +84,8 @@ export const LearningPageScaffolding = (props: ContentfulContent) =>
   </Layout>); 
 
 
-export const LearningPageQuery = graphql`
-  fragment LearningPageQuery on Query {
+export const LearningPageFragment = graphql`
+  fragment LearningPage on Query {
     contentfulLearningCenterSearchPage( node_locale: { eq: $locale } ) {
       metadata {
         title
@@ -139,7 +139,7 @@ export const LearningPageQuery = graphql`
 const LearningPage  = () => (
   <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...LearningPageQuery }
+    query ($locale: String! = "en-US") { ...LearningPage }
   `}
   render = {data => (<LearningPageScaffolding content={data.contentfulLearningCenterSearchPage} />)}
   />

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -84,60 +84,63 @@ export const LearningPageScaffolding = (props: ContentfulContent) =>
   </Layout>); 
 
 
-const LearningPage  = () => (
-  <StaticQuery
-    query={graphql`
-      query {
-        contentfulLearningCenterSearchPage {
-          metadata {
-            title
-            description
-            keywords {
-              keywords
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          headerImage {
-            file {
-              url
-            }
-          }
-          subtitle
-          articles {
-            slug
-            title
-            previewText {
-              previewText
-            }
-            categories {
-              title
-              description
-              slug
-            }
-          }
-          learningCenterCta {
-            title
-            subtitle
-            ctaText
-            ctaLink
-          }
-          justFixCta {
-            title
-            subtitle
-            ctaText
-            ctaLink
-          }
-          thankYouText {
-            json
+export const LearningPageQuery = graphql`
+  fragment LearningPageQuery on Query {
+    contentfulLearningCenterSearchPage( node_locale: { eq: $locale } ) {
+      metadata {
+        title
+        description
+        keywords {
+          keywords
+        }
+        shareImage {
+          file {
+            url
           }
         }
       }
-    `}
+      title
+      headerImage {
+        file {
+          url
+        }
+      }
+      subtitle
+      articles {
+        slug
+        title
+        previewText {
+          previewText
+        }
+        categories {
+          title
+          description
+          slug
+        }
+      }
+      learningCenterCta {
+        title
+        subtitle
+        ctaText
+        ctaLink
+      }
+      justFixCta {
+        title
+        subtitle
+        ctaText
+        ctaLink
+      }
+      thankYouText {
+        json
+      }
+    }
+  }`;
+
+const LearningPage  = () => (
+  <StaticQuery
+  query={graphql`
+    query ($locale: String! = "en-US") { ...LearningPageQuery }
+  `}
   render = {data => (<LearningPageScaffolding content={data.contentfulLearningCenterSearchPage} />)}
   />
 );

--- a/src/pages/our-mission.es.tsx
+++ b/src/pages/our-mission.es.tsx
@@ -5,7 +5,7 @@ import { MissionPageScaffolding } from './our-mission';
 const MissionPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...MissionPageQuery }
+    query ($locale: String! = "es") { ...MissionPage }
   `}
   render = {data => (<MissionPageScaffolding content={data.contentfulMissionPage} locale="es" />)}
   />

--- a/src/pages/our-mission.es.tsx
+++ b/src/pages/our-mission.es.tsx
@@ -4,47 +4,9 @@ import { MissionPageScaffolding } from './our-mission';
 
 const MissionPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulMissionPage( node_locale: { eq: "es" } ) {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          briefDescription
-          videoUrl
-          serveSection {
-            json
-          }
-          impactTitle
-          impactSubtitle
-          impactReportButtons {
-            title
-            link
-          }
-          approachSection {
-            json
-          }
-          collaborationBanner {
-            title
-            subtitle
-          }
-          readMore {
-            title
-            link
-          }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...MissionPageQuery }
+  `}
   render = {data => (<MissionPageScaffolding content={data.contentfulMissionPage} locale="es" />)}
   />
 );

--- a/src/pages/our-mission.tsx
+++ b/src/pages/our-mission.tsx
@@ -94,8 +94,8 @@ export const MissionPageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
-export const MissionPageQuery = graphql`
-  fragment MissionPageQuery on Query {
+export const MissionPageFragment = graphql`
+  fragment MissionPage on Query {
     contentfulMissionPage( node_locale: { eq: $locale } )  {
       metadata {
         title
@@ -138,7 +138,7 @@ export const MissionPageQuery = graphql`
 const MissionPage  = () => (
 <StaticQuery
   query={graphql`
-   query ($locale: String! = "en-US") { ...MissionPageQuery }
+   query ($locale: String! = "en-US") { ...MissionPage }
  `}
   render = {data => (<MissionPageScaffolding content={data.contentfulMissionPage} />)}
   />

--- a/src/pages/our-mission.tsx
+++ b/src/pages/our-mission.tsx
@@ -94,49 +94,52 @@ export const MissionPageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
-const MissionPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulMissionPage {
-          metadata {
-            title
-            description
-            keywords { 
-              keywords 
-            }
-            shareImage {
-              file {
-                url
-              }
-            }
-          }
-          title
-          briefDescription
-          videoUrl
-          serveSection {
-            json
-          }
-          impactTitle
-          impactSubtitle
-          impactReportButtons {
-            title
-            link
-          }
-          approachSection {
-            json
-          }
-          collaborationBanner {
-            title
-            subtitle
-          }
-          readMore {
-            title
-            link
+export const MissionPageQuery = graphql`
+  fragment MissionPageQuery on Query {
+    contentfulMissionPage( node_locale: { eq: $locale } )  {
+      metadata {
+        title
+        description
+        keywords { 
+          keywords 
+        }
+        shareImage {
+          file {
+            url
           }
         }
       }
-    `}
+      title
+      briefDescription
+      videoUrl
+      serveSection {
+        json
+      }
+      impactTitle
+      impactSubtitle
+      impactReportButtons {
+        title
+        link
+      }
+      approachSection {
+        json
+      }
+      collaborationBanner {
+        title
+        subtitle
+      }
+      readMore {
+        title
+        link
+      }
+    }
+  }`;
+
+const MissionPage  = () => (
+<StaticQuery
+  query={graphql`
+   query ($locale: String! = "en-US") { ...MissionPageQuery }
+ `}
   render = {data => (<MissionPageScaffolding content={data.contentfulMissionPage} />)}
   />
 );

--- a/src/pages/privacy-policy.es.tsx
+++ b/src/pages/privacy-policy.es.tsx
@@ -5,7 +5,7 @@ import { PrivacyPolicyPageScaffolding } from './privacy-policy';
 const PrivacyPolicyPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...PrivacyPolicyQuery }
+    query ($locale: String! = "es") { ...PrivacyPolicyPageQuery }
   `}
   render = {data => (<PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} locale="es" />)}
   />

--- a/src/pages/privacy-policy.es.tsx
+++ b/src/pages/privacy-policy.es.tsx
@@ -5,7 +5,7 @@ import { PrivacyPolicyPageScaffolding } from './privacy-policy';
 const PrivacyPolicyPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...PrivacyPolicyPageQuery }
+    query ($locale: String! = "es") { ...PrivacyPolicyPage }
   `}
   render = {data => (<PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} locale="es" />)}
   />

--- a/src/pages/privacy-policy.es.tsx
+++ b/src/pages/privacy-policy.es.tsx
@@ -4,16 +4,9 @@ import { PrivacyPolicyPageScaffolding } from './privacy-policy';
 
 const PrivacyPolicyPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulGenericPage(title: {eq: "Privacy Policy"}) {
-            title
-            pageContents {
-              json
-            }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...PrivacyPolicyQuery }
+  `}
   render = {data => (<PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} locale="es" />)}
   />
 );

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -12,8 +12,8 @@ export const PrivacyPolicyPageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
-export const PrivacyPolicyPageQuery = graphql`
-  fragment PrivacyPolicyPageQuery on Query {
+export const PrivacyPolicyPageFragment = graphql`
+  fragment PrivacyPolicyPage on Query {
     contentfulGenericPage(title: {eq: "Privacy Policy"}, node_locale: {eq: $locale}) {
         title
         pageContents {
@@ -25,7 +25,7 @@ export const PrivacyPolicyPageQuery = graphql`
 const PrivacyPolicyPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...PrivacyPolicyPageQuery }
+    query ($locale: String! = "en-US") { ...PrivacyPolicyPage }
   `}
   render = {data => (<PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} />)}
   />

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -12,18 +12,21 @@ export const PrivacyPolicyPageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
+export const PrivacyPolicyQuery = graphql`
+  fragment PrivacyPolicyQuery on Query {
+    contentfulGenericPage(title: {eq: "Privacy Policy"}, node_locale: {eq: $locale}) {
+        title
+        pageContents {
+          json
+        }
+    }
+  }`;
+
 const PrivacyPolicyPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulGenericPage(title: {eq: "Privacy Policy"}) {
-            title
-            pageContents {
-              json
-            }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "en-US") { ...PrivacyPolicyQuery }
+  `}
   render = {data => (<PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} />)}
   />
 );

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -12,8 +12,8 @@ export const PrivacyPolicyPageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
-export const PrivacyPolicyQuery = graphql`
-  fragment PrivacyPolicyQuery on Query {
+export const PrivacyPolicyPageQuery = graphql`
+  fragment PrivacyPolicyPageQuery on Query {
     contentfulGenericPage(title: {eq: "Privacy Policy"}, node_locale: {eq: $locale}) {
         title
         pageContents {
@@ -25,7 +25,7 @@ export const PrivacyPolicyQuery = graphql`
 const PrivacyPolicyPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...PrivacyPolicyQuery }
+    query ($locale: String! = "en-US") { ...PrivacyPolicyPageQuery }
   `}
   render = {data => (<PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} />)}
   />

--- a/src/pages/subscribed.es.tsx
+++ b/src/pages/subscribed.es.tsx
@@ -5,7 +5,7 @@ import { SubscribedPageScaffolding } from './subscribed';
 const SubscribedPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...SubscribedPageQuery }
+    query ($locale: String! = "es") { ...SubscribedPage }
   `}
   render = {data => (<SubscribedPageScaffolding content={data.contentfulSubscriptionConfirmationPage} locale="es" />)}
   />

--- a/src/pages/subscribed.es.tsx
+++ b/src/pages/subscribed.es.tsx
@@ -5,7 +5,7 @@ import { SubscribedPageScaffolding } from './subscribed';
 const SubscribedPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...SubscribedQuery }
+    query ($locale: String! = "es") { ...SubscribedPageQuery }
   `}
   render = {data => (<SubscribedPageScaffolding content={data.contentfulSubscriptionConfirmationPage} locale="es" />)}
   />

--- a/src/pages/subscribed.es.tsx
+++ b/src/pages/subscribed.es.tsx
@@ -4,24 +4,9 @@ import { SubscribedPageScaffolding } from './subscribed';
 
 const SubscribedPage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulSubscriptionConfirmationPage( node_locale: { eq: "es" } ) {
-            title
-            description {
-                json
-            }
-            teamPhoto {
-                file {
-                    url
-                }
-            }
-            descriptionBelowPhoto {
-                json
-            }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...SubscribedQuery }
+  `}
   render = {data => (<SubscribedPageScaffolding content={data.contentfulSubscriptionConfirmationPage} locale="es" />)}
   />
 );

--- a/src/pages/subscribed.tsx
+++ b/src/pages/subscribed.tsx
@@ -31,11 +31,9 @@ export const SubscribedPageScaffolding = (props: ContentfulContent) =>
     </section>
   </Layout>); 
 
-const SubscribedPage  = () => (
-<StaticQuery
-    query={graphql`
-      query {
-        contentfulSubscriptionConfirmationPage {
+export const SubscribedQuery = graphql`
+    fragment SubscribedQuery on Query {
+        contentfulSubscriptionConfirmationPage( node_locale: { eq: $locale } ) {
             title
             description {
                 json
@@ -49,8 +47,13 @@ const SubscribedPage  = () => (
                 json
             }
         }
-      }
-    `}
+    }`;
+
+const SubscribedPage  = () => (
+<StaticQuery
+  query={graphql`
+    query ($locale: String! = "en-US") { ...SubscribedQuery }
+`}
   render = {data => (<SubscribedPageScaffolding content={data.contentfulSubscriptionConfirmationPage} />)}
   />
 );

--- a/src/pages/subscribed.tsx
+++ b/src/pages/subscribed.tsx
@@ -31,8 +31,8 @@ export const SubscribedPageScaffolding = (props: ContentfulContent) =>
     </section>
   </Layout>); 
 
-export const SubscribedQuery = graphql`
-    fragment SubscribedQuery on Query {
+export const SubscribedPageQuery = graphql`
+    fragment SubscribedPageQuery on Query {
         contentfulSubscriptionConfirmationPage( node_locale: { eq: $locale } ) {
             title
             description {
@@ -52,7 +52,7 @@ export const SubscribedQuery = graphql`
 const SubscribedPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...SubscribedQuery }
+    query ($locale: String! = "en-US") { ...SubscribedPageQuery }
 `}
   render = {data => (<SubscribedPageScaffolding content={data.contentfulSubscriptionConfirmationPage} />)}
   />

--- a/src/pages/subscribed.tsx
+++ b/src/pages/subscribed.tsx
@@ -31,8 +31,8 @@ export const SubscribedPageScaffolding = (props: ContentfulContent) =>
     </section>
   </Layout>); 
 
-export const SubscribedPageQuery = graphql`
-    fragment SubscribedPageQuery on Query {
+export const SubscribedPageFragment = graphql`
+    fragment SubscribedPage on Query {
         contentfulSubscriptionConfirmationPage( node_locale: { eq: $locale } ) {
             title
             description {
@@ -52,7 +52,7 @@ export const SubscribedPageQuery = graphql`
 const SubscribedPage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...SubscribedPageQuery }
+    query ($locale: String! = "en-US") { ...SubscribedPage }
 `}
   render = {data => (<SubscribedPageScaffolding content={data.contentfulSubscriptionConfirmationPage} />)}
   />

--- a/src/pages/terms-of-use.es.tsx
+++ b/src/pages/terms-of-use.es.tsx
@@ -6,7 +6,7 @@ import { TermsOfUsePageScaffolding } from './terms-of-use';
 const TermsOfUsePage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...TermsOfUsePageQuery }
+    query ($locale: String! = "es") { ...TermsOfUsePage }
   `}
   render = {data => (<TermsOfUsePageScaffolding content={data.contentfulGenericPage} locale="es" />)}
   />

--- a/src/pages/terms-of-use.es.tsx
+++ b/src/pages/terms-of-use.es.tsx
@@ -5,16 +5,9 @@ import { TermsOfUsePageScaffolding } from './terms-of-use';
 
 const TermsOfUsePage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulGenericPage(title: {eq: "Terms of Use"}) {
-            title
-            pageContents {
-              json
-            }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "es") { ...TermsOfUseQuery }
+  `}
   render = {data => (<TermsOfUsePageScaffolding content={data.contentfulGenericPage} locale="es" />)}
   />
 );

--- a/src/pages/terms-of-use.es.tsx
+++ b/src/pages/terms-of-use.es.tsx
@@ -6,7 +6,7 @@ import { TermsOfUsePageScaffolding } from './terms-of-use';
 const TermsOfUsePage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "es") { ...TermsOfUseQuery }
+    query ($locale: String! = "es") { ...TermsOfUsePageQuery }
   `}
   render = {data => (<TermsOfUsePageScaffolding content={data.contentfulGenericPage} locale="es" />)}
   />

--- a/src/pages/terms-of-use.tsx
+++ b/src/pages/terms-of-use.tsx
@@ -12,8 +12,8 @@ export const TermsOfUsePageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
-export const TermsOfUseQuery = graphql`
-  fragment TermsOfUseQuery on Query {
+export const TermsOfUsePageQuery = graphql`
+  fragment TermsOfUsePageQuery on Query {
     contentfulGenericPage(title: {eq: "Terms of Use"}, node_locale: {eq: $locale}) {
         title
         pageContents {
@@ -25,7 +25,7 @@ export const TermsOfUseQuery = graphql`
 const TermsOfUsePage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...TermsOfUseQuery }
+    query ($locale: String! = "en-US") { ...TermsOfUsePageQuery }
   `}
   render = {data => (<TermsOfUsePageScaffolding content={data.contentfulGenericPage} />)}
   />

--- a/src/pages/terms-of-use.tsx
+++ b/src/pages/terms-of-use.tsx
@@ -12,8 +12,8 @@ export const TermsOfUsePageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
-export const TermsOfUsePageQuery = graphql`
-  fragment TermsOfUsePageQuery on Query {
+export const TermsOfUsePageFragment = graphql`
+  fragment TermsOfUsePage on Query {
     contentfulGenericPage(title: {eq: "Terms of Use"}, node_locale: {eq: $locale}) {
         title
         pageContents {
@@ -25,7 +25,7 @@ export const TermsOfUsePageQuery = graphql`
 const TermsOfUsePage  = () => (
 <StaticQuery
   query={graphql`
-    query ($locale: String! = "en-US") { ...TermsOfUsePageQuery }
+    query ($locale: String! = "en-US") { ...TermsOfUsePage }
   `}
   render = {data => (<TermsOfUsePageScaffolding content={data.contentfulGenericPage} />)}
   />

--- a/src/pages/terms-of-use.tsx
+++ b/src/pages/terms-of-use.tsx
@@ -12,18 +12,21 @@ export const TermsOfUsePageScaffolding = (props: ContentfulContent) =>
     </div>
   </Layout>); 
 
+export const TermsOfUseQuery = graphql`
+  fragment TermsOfUseQuery on Query {
+    contentfulGenericPage(title: {eq: "Terms of Use"}, node_locale: {eq: $locale}) {
+        title
+        pageContents {
+          json
+        }
+    }
+  }`;
+
 const TermsOfUsePage  = () => (
 <StaticQuery
-    query={graphql`
-      query {
-        contentfulGenericPage(title: {eq: "Terms of Use"}) {
-            title
-            pageContents {
-              json
-            }
-        }
-      }
-    `}
+  query={graphql`
+    query ($locale: String! = "en-US") { ...TermsOfUseQuery }
+  `}
   render = {data => (<TermsOfUsePageScaffolding content={data.contentfulGenericPage} />)}
   />
 );


### PR DESCRIPTION
Using @toolness's suggestions from #97, I refactored all of our page queries to be exportable graphql fragments so that localized page duplicates can just reuse them (less DRY).  