### PR TITLE
Added norent privacy policy page

### DIFF
--- a/src/pages/privacy-policy-norent.es.tsx
+++ b/src/pages/privacy-policy-norent.es.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+import { NorentPrivacyPolicyPageScaffolding } from "./privacy-policy-norent";
+
+const NorentPrivacyPolicyPage = () => (
+  <StaticQuery
+    query={graphql`
+      query($locale: String! = "es") {
+        ...NorentPrivacyPolicyPage
+      }
+    `}
+    render={(data) => (
+      <NorentPrivacyPolicyPageScaffolding
+        content={data.contentfulGenericPage}
+        locale="es"
+      />
+    )}
+  />
+);
+
+export default NorentPrivacyPolicyPage;

--- a/src/pages/privacy-policy-norent.tsx
+++ b/src/pages/privacy-policy-norent.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+
+import Layout from "../components/layout";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { ContentfulContent } from ".";
+
+export const NorentPrivacyPolicyPageScaffolding = (
+  props: ContentfulContent
+) => (
+  <Layout metadata={{ title: "Privacy Policy NoRent" }} locale={props.locale}>
+    <div
+      id="privacy-policy"
+      className="privacy-policy-page content-wrapper tight section"
+    >
+      <div className="content">
+        {documentToReactComponents(props.content.pageContents.json)}
+      </div>
+    </div>
+  </Layout>
+);
+
+export const NorentPrivacyPolicyPageFragment = graphql`
+  fragment NorentPrivacyPolicyPage on Query {
+    contentfulGenericPage(
+      title: { eq: "NoRent Privacy Policy" }
+      node_locale: { eq: $locale }
+    ) {
+      title
+      pageContents {
+        json
+      }
+    }
+  }
+`;
+
+const NorentPrivacyPolicyPage = () => (
+  <StaticQuery
+    query={graphql`
+      query($locale: String! = "en-US") {
+        ...NorentPrivacyPolicyPage
+      }
+    `}
+    render={(data) => (
+      <NorentPrivacyPolicyPageScaffolding
+        content={data.contentfulGenericPage}
+      />
+    )}
+  />
+);
+
+export default NorentPrivacyPolicyPage;

--- a/src/pages/privacy-policy-norent.tsx
+++ b/src/pages/privacy-policy-norent.tsx
@@ -8,7 +8,7 @@ import { ContentfulContent } from ".";
 export const NorentPrivacyPolicyPageScaffolding = (
   props: ContentfulContent
 ) => (
-  <Layout metadata={{ title: "Privacy Policy NoRent" }} locale={props.locale}>
+  <Layout metadata={{ title: "Privacy Policy for NoRent" }} locale={props.locale}>
     <div
       id="privacy-policy"
       className="privacy-policy-page content-wrapper tight section"


### PR DESCRIPTION
This adds a route for the NoRent Privacy Policy page at the path `/privacy-policy-norent`. Content of the page to be updated on Contentful once finalized by legal partners.