### PR TITLE
Refactored Mailchimp signups in footer to use new external API

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,3 +43,15 @@ SITE_URL=
 ## Setting DEMO SITE to 1 will add a "Demo Site" label to the header.
 
 GATSBY_DEMO_SITE=
+
+# =========================
+# TENANT PLATFORM SITE ORIGIN (OPTIONAL)
+# =========================
+# 
+# Setting TENANT PLATFORM SITE ORIGIN to the origin url of a server 
+# will configure the external database that certain features communicate with.
+# 
+# For example, setting this to `https://app.justfix.nyc` will allow our email sign-ups to get 
+# processed by our MailChimp endpoint on the JustFix Tenant Platform. 
+
+GATSBY_TENANT_PLATFORM_SITE_ORIGIN=

--- a/src/components/ddo-searchbar.tsx
+++ b/src/components/ddo-searchbar.tsx
@@ -8,9 +8,8 @@ import classnames from "classnames";
 
 /** The URL for Data-Driven Onboarding (DDO) on the JustFix Tenant Platform. */
 const DDO_URL =
-  "https://" +
-  (process.env.GATSBY_DEMO_SITE === "1" ? "demo" : "app") +
-  ".justfix.nyc/ddo";
+  (process.env.GATSBY_TENANT_PLATFORM_SITE_ORIGIN ||
+    "https://demo.justfix.nyc") + "/ddo";
 
 /** The querystring variable used to communicate the address for DDO. */
 const DDO_ADDRESS_VAR = "address";

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,14 +1,12 @@
 import React from "react";
 import { SocialIcon } from "react-social-icons";
 import { Link } from "gatsby";
-import { Trans, t } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 
 import "../styles/footer.scss";
 import { Locale } from "../pages";
-
-const MAILCHIMP_URL =
-  "https://nyc.us13.list-manage.com/subscribe/post?u=d4f5d1addd4357eb77c3f8a99&amp;id=588f6c6ef4";
+import Subscribe from "./subscribe";
 
 const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
   const localePrefix = locale ? "/" + locale : "";
@@ -113,32 +111,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           <h4 className="title is-size-5 has-text-white">
             <Trans>Join our mailing list!</Trans>
           </h4>
-          <form
-            action={MAILCHIMP_URL}
-            className="email-form is-horizontal-center"
-            method="post"
-            target="_blank"
-          >
-            <div className="mc-field-group">
-              <div className="control is-expanded">
-                <input
-                  type="email"
-                  name="EMAIL"
-                  className="required email input"
-                  id="mce-EMAIL"
-                  placeholder={i18n._(t`Email Address`)}
-                />
-              </div>
-              <div className="control has-text-centered-touch">
-                <button
-                  className="button is-primary is-uppercase"
-                  type="submit"
-                >
-                  <Trans>Sign up</Trans>
-                </button>
-              </div>
-            </div>
-          </form>
+          <Subscribe />
           <div className="field">
             <SocialIcon
               url="http://twitter.com/justfixnyc"

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -8,7 +8,8 @@ import { Locale } from "../pages";
 const isDemoSite = process.env.GATSBY_DEMO_SITE === "1";
 
 const TENANT_PLATFORM_URL =
-  "https://" + (isDemoSite ? "demo" : "app") + ".justfix.nyc/login";
+  (process.env.GATSBY_TENANT_PLATFORM_SITE_ORIGIN ||
+    "https://demo.justfix.nyc") + "/login";
 
 type Props = {
   isLandingPage?: boolean;

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -2,8 +2,11 @@ import React from "react";
 import { Trans, t } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 import { Locale } from "../pages";
+import classnames from "classnames";
 
-type SubscribeProps = Locale & withI18nProps;
+type FormLocation = "footer" | "page";
+
+type SubscribeProps = { location?: FormLocation } & Locale & withI18nProps;
 
 type SubscribeState = {
   email: string;
@@ -84,11 +87,21 @@ class SubscribeWithoutI18n extends React.Component<
   };
 
   render() {
-    const { i18n } = this.props;
+    const { i18n, location } = this.props;
+
+    // Default styling is for "footer"
+    const defaultResponseTextClass =
+      location === "page" ? "has-text-grey-dark" : "has-text-white";
+
     return (
       <div>
-        <form className="is-horizontal-center" onSubmit={this.handleSubmit}>
-          <div>
+        <form
+          className="email-form is-horizontal-center"
+          onSubmit={this.handleSubmit}
+        >
+          <div
+            className={classnames(location === "page" && "field has-addons")}
+          >
             <div className="control is-expanded">
               <input
                 type="email"
@@ -109,7 +122,9 @@ class SubscribeWithoutI18n extends React.Component<
           <>
             <p
               className={
-                this.state.success ? "has-text-white" : "has-text-danger"
+                this.state.success
+                  ? defaultResponseTextClass
+                  : "has-text-danger"
               }
             >
               {this.state.response}

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -91,6 +91,7 @@ class SubscribeWithoutI18n extends React.Component<
               <input
                 type="email"
                 name="EMAIL"
+                className="input"
                 onChange={this.handleChange}
                 placeholder={i18n._(t`Email Address`)}
               />

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -50,7 +50,9 @@ class SubscribeWithoutI18n extends React.Component<
     fetch(`${tenantPlatformOrigin}/mailchimp/subscribe`, {
       method: "POST",
       mode: "cors",
-      body: `email=${encodeURIComponent(email)}&language=${locale}&source=orgsite`,
+      body: `email=${encodeURIComponent(
+        email
+      )}&language=${locale}&source=orgsite`,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -50,7 +50,7 @@ class SubscribeWithoutI18n extends React.Component<
     fetch(`${tenantPlatformOrigin}/mailchimp/subscribe`, {
       method: "POST",
       mode: "cors",
-      body: `email=${encodeURIComponent(email)}&language=${locale}&source=wow`,
+      body: `email=${encodeURIComponent(email)}&language=${locale}&source=orgsite`,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { Trans, t } from "@lingui/macro";
+import { withI18n, withI18nProps } from "@lingui/react";
+import { Locale } from "../pages";
+
+type SubscribeProps = Locale & withI18nProps;
+
+type SubscribeState = {
+  email: string;
+  success: boolean;
+  response: string;
+};
+
+class SubscribeWithoutI18n extends React.Component<
+  SubscribeProps,
+  SubscribeState
+> {
+  constructor(props: SubscribeProps) {
+    super(props);
+    this.state = {
+      email: "",
+      success: false,
+      response: "",
+    };
+  }
+
+  handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({ email: e.target.value });
+  };
+
+  handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const email = this.state.email || null;
+    const { i18n } = this.props;
+    const locale = i18n.language;
+
+    // check if email is missing, return undefined
+    if (!email) {
+      this.setState({
+        response: i18n._(t`Please enter an email address!`),
+      });
+      return;
+    }
+
+    const tenantPlatformOrigin =
+      process.env.GATSBY_TENANT_PLATFORM_SITE_ORIGIN ||
+      "https://demo.justfix.nyc";
+
+    fetch(`${tenantPlatformOrigin}/mailchimp/subscribe`, {
+      method: "POST",
+      mode: "cors",
+      body: `email=${encodeURIComponent(email)}&language=${locale}&source=wow`,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    })
+      .then((result) => result.json())
+      .then((result) => {
+        if (result.status === 200) {
+          this.setState({
+            success: true,
+            response: i18n._(t`All set! Thanks for subscribing!`),
+          });
+        } else if (result.errorCode === "INVALID_EMAIL") {
+          this.setState({
+            response: i18n._(t`Oops! That email is invalid.`),
+          });
+        } else {
+          this.setState({
+            response: i18n._(
+              t`Oops! A network error occurred. Try again later.`
+            ),
+          });
+        }
+      })
+      .catch((err) => {
+        this.setState({
+          response: i18n._(t`Oops! A network error occurred. Try again later.`),
+        });
+      });
+  };
+
+  render() {
+    const { i18n } = this.props;
+    return (
+      <div>
+        <form className="is-horizontal-center" onSubmit={this.handleSubmit}>
+          <div>
+            <div className="control is-expanded">
+              <input
+                type="email"
+                name="EMAIL"
+                onChange={this.handleChange}
+                placeholder={i18n._(t`Email Address`)}
+              />
+            </div>
+            <div className="control has-text-centered-touch">
+              <button className="button is-primary is-uppercase" type="submit">
+                <Trans>Sign up</Trans>
+              </button>
+            </div>
+          </div>
+        </form>
+        {this.state.response && (
+          <>
+            <p
+              className={
+                this.state.success ? "has-text-white" : "has-text-danger"
+              }
+            >
+              {this.state.response}
+            </p>
+            <br />
+          </>
+        )}
+      </div>
+    );
+  }
+}
+
+const Subscribe = withI18n()(SubscribeWithoutI18n);
+
+export default Subscribe;

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -30,7 +30,7 @@ msgstr ""
 msgid "About us"
 msgstr ""
 
-#: src/components/subscribe.tsx:37
+#: src/components/subscribe.tsx:38
 msgid "All set! Thanks for subscribing!"
 msgstr ""
 
@@ -60,8 +60,7 @@ msgstr ""
 msgid "Donate"
 msgstr ""
 
-#: src/components/subscribe.tsx:69
-#: src/pages/contact-us.tsx:39
+#: src/components/subscribe.tsx:72
 msgid "Email Address"
 msgstr ""
 
@@ -98,12 +97,12 @@ msgstr ""
 msgid "Not found"
 msgstr ""
 
-#: src/components/subscribe.tsx:47
-#: src/components/subscribe.tsx:53
+#: src/components/subscribe.tsx:48
+#: src/components/subscribe.tsx:54
 msgid "Oops! A network error occurred. Try again later."
 msgstr ""
 
-#: src/components/subscribe.tsx:42
+#: src/components/subscribe.tsx:43
 msgid "Oops! That email is invalid."
 msgstr ""
 
@@ -112,7 +111,7 @@ msgstr ""
 msgid "Partners"
 msgstr ""
 
-#: src/components/subscribe.tsx:18
+#: src/components/subscribe.tsx:19
 msgid "Please enter an email address!"
 msgstr ""
 
@@ -148,8 +147,7 @@ msgstr ""
 msgid "Sign in"
 msgstr ""
 
-#: src/components/subscribe.tsx:73
-#: src/pages/contact-us.tsx:44
+#: src/components/subscribe.tsx:76
 msgid "Sign up"
 msgstr ""
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,111 +13,128 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/header.tsx:14
+#: src/components/header.tsx:15
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr ""
 
-#: src/components/footer.tsx:82
+#: src/components/footer.tsx:93
 msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr ""
 
-#: src/components/footer.tsx:83
+#: src/components/footer.tsx:102
 msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr ""
 
-#: src/components/footer.tsx:35
-#: src/components/header.tsx:62
+#: src/components/footer.tsx:45
+#: src/components/header.tsx:67
 msgid "About us"
 msgstr ""
 
-#: src/components/learning-center/category-page-template.tsx:27
+#: src/components/subscribe.tsx:37
+msgid "All set! Thanks for subscribing!"
+msgstr ""
+
+#: src/components/learning-center/category-page-template.tsx:32
 msgid "Back to Overview"
 msgstr ""
 
-#: src/components/learning-center/article-template.tsx:55
+#: src/components/learning-center/article-template.tsx:50
 msgid "Back to top"
 msgstr ""
 
-#: src/components/footer.tsx:46
-#: src/components/header.tsx:93
+#: src/components/footer.tsx:64
+#: src/components/header.tsx:101
 msgid "Contact"
 msgstr ""
 
-#: src/pages/our-mission.tsx:21
+#: src/pages/our-mission.tsx:19
 msgid "Contact Us"
 msgstr ""
 
-#: src/components/header.tsx:47
+#: src/components/header.tsx:51
 msgid "DEMO SITE"
 msgstr ""
 
-#: src/components/footer.tsx:49
-#: src/pages/our-mission.tsx:23
+#: src/components/footer.tsx:69
+#: src/pages/our-mission.tsx:22
 msgid "Donate"
 msgstr ""
 
-#: src/components/footer.tsx:60
-#: src/pages/contact-us.tsx:40
+#: src/components/subscribe.tsx:69
+#: src/pages/contact-us.tsx:39
 msgid "Email Address"
 msgstr ""
 
-#: src/components/learning-center/all-tools-cta.tsx:19
+#: src/components/learning-center/all-tools-cta.tsx:18
 #: src/pages/index.tsx:19
 #: src/pages/index.tsx:23
 msgid "Enter your address to learn more."
 msgstr ""
 
-#: src/components/footer.tsx:43
-#: src/components/header.tsx:79
+#: src/components/footer.tsx:59
+#: src/components/header.tsx:84
 msgid "Jobs"
 msgstr ""
 
-#: src/components/footer.tsx:55
+#: src/components/footer.tsx:76
 msgid "Join our mailing list!"
 msgstr ""
 
-#: src/components/footer.tsx:24
-#: src/components/header.tsx:89
+#: src/components/footer.tsx:28
+#: src/components/header.tsx:96
 msgid "Learn"
 msgstr ""
 
-#: src/components/footer.tsx:27
-#: src/components/header.tsx:67
+#: src/components/footer.tsx:33
+#: src/components/header.tsx:72
 msgid "Mission"
 msgstr ""
 
-#: src/components/learning-center/learning-searchbar.tsx:26
+#: src/components/learning-center/learning-searchbar.tsx:32
 msgid "No articles match your search."
 msgstr ""
 
-#: src/pages/404.tsx:7
+#: src/pages/404.tsx:8
 msgid "Not found"
 msgstr ""
 
-#: src/components/footer.tsx:40
-#: src/components/header.tsx:73
+#: src/components/subscribe.tsx:47
+#: src/components/subscribe.tsx:53
+msgid "Oops! A network error occurred. Try again later."
+msgstr ""
+
+#: src/components/subscribe.tsx:42
+msgid "Oops! That email is invalid."
+msgstr ""
+
+#: src/components/footer.tsx:54
+#: src/components/header.tsx:78
 msgid "Partners"
 msgstr ""
 
-#: src/components/footer.tsx:30
-#: src/components/header.tsx:76
+#: src/components/subscribe.tsx:18
+msgid "Please enter an email address!"
+msgstr ""
+
+#: src/components/footer.tsx:38
+#: src/components/header.tsx:81
 msgid "Press"
 msgstr ""
 
-#: src/components/footer.tsx:85
+#: src/components/footer.tsx:108
 msgid "Privacy policy"
 msgstr ""
 
-#: src/components/footer.tsx:21
-#: src/components/header.tsx:85
+#: src/components/footer.tsx:23
+#: src/components/header.tsx:91
 msgid "Products"
 msgstr ""
 
-#: src/pages/learn.tsx:28
+#: src/pages/learn.tsx:33
 msgid "Read More"
 msgstr ""
 
-#: src/components/learning-center/all-tools-cta.tsx:19
+#: src/components/learning-center/all-tools-cta.tsx:18
 #: src/pages/index.tsx:23
 msgid "Search address"
 msgstr ""
@@ -126,34 +143,34 @@ msgstr ""
 msgid "Search articles..."
 msgstr ""
 
-#: src/components/header.tsx:100
 #: src/components/header.tsx:107
+#: src/components/header.tsx:113
 msgid "Sign in"
 msgstr ""
 
-#: src/components/footer.tsx:64
+#: src/components/subscribe.tsx:73
 #: src/pages/contact-us.tsx:44
 msgid "Sign up"
 msgstr ""
 
-#: src/components/footer.tsx:37
-#: src/components/header.tsx:70
+#: src/components/footer.tsx:49
+#: src/components/header.tsx:75
 msgid "Team"
 msgstr ""
 
-#: src/components/footer.tsx:88
+#: src/components/footer.tsx:111
 msgid "Terms of use"
 msgstr ""
 
-#: src/components/learning-center/article-template.tsx:97
+#: src/components/learning-center/article-template.tsx:103
 msgid "Updated"
 msgstr ""
 
-#: src/components/read-more.tsx:10
+#: src/components/read-more.tsx:11
 msgid "Want to know more?"
 msgstr ""
 
-#: src/components/learning-center/article-template.tsx:21
+#: src/components/learning-center/article-template.tsx:20
 msgid "Want to take action?"
 msgstr ""
 
@@ -161,10 +178,10 @@ msgstr ""
 msgid "What we do"
 msgstr ""
 
-#: src/components/learning-center/article-template.tsx:95
+#: src/components/learning-center/article-template.tsx:99
 msgid "Written by"
 msgstr ""
 
-#: src/pages/404.tsx:8
+#: src/pages/404.tsx:11
 msgid "You just found a page that doesn't exist... the sadness."
 msgstr ""

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -35,7 +35,7 @@ msgstr "Sobre nosotros"
 
 #: src/components/subscribe.tsx:38
 msgid "All set! Thanks for subscribing!"
-msgstr ""
+msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
 #: src/components/learning-center/category-page-template.tsx:32
 msgid "Back to Overview"
@@ -103,11 +103,11 @@ msgstr "No encontrado"
 #: src/components/subscribe.tsx:48
 #: src/components/subscribe.tsx:54
 msgid "Oops! A network error occurred. Try again later."
-msgstr ""
+msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 
 #: src/components/subscribe.tsx:43
 msgid "Oops! That email is invalid."
-msgstr ""
+msgstr "¡Vaya! Ese correo electrónico no es válido."
 
 #: src/components/footer.tsx:54
 #: src/components/header.tsx:78
@@ -116,7 +116,7 @@ msgstr "Aliados"
 
 #: src/components/subscribe.tsx:19
 msgid "Please enter an email address!"
-msgstr ""
+msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
 #: src/components/footer.tsx:38
 #: src/components/header.tsx:81

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -16,111 +16,128 @@ msgstr ""
 "X-Crowdin-Language: es-ES\n"
 "X-Crowdin-File: /master/src/locales/en/messages.po\n"
 
-#: src/components/header.tsx:14
+#: src/components/header.tsx:15
 msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
 msgstr ""
 
-#: src/components/footer.tsx:82
+#: src/components/footer.tsx:93
 msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "<0>Aviso:</0> La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarle a dirigirle a servicios legales gratuitos si es necesario."
 
-#: src/components/footer.tsx:83
+#: src/components/footer.tsx:102
 msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr "<0>JustFix.nyc</0> es una organización sin fines de lucro registrada."
 
-#: src/components/footer.tsx:35
-#: src/components/header.tsx:62
+#: src/components/footer.tsx:45
+#: src/components/header.tsx:67
 msgid "About us"
 msgstr "Sobre nosotros"
 
-#: src/components/learning-center/category-page-template.tsx:27
+#: src/components/subscribe.tsx:37
+msgid "All set! Thanks for subscribing!"
+msgstr ""
+
+#: src/components/learning-center/category-page-template.tsx:32
 msgid "Back to Overview"
 msgstr "Vuelve a Vista General"
 
-#: src/components/learning-center/article-template.tsx:55
+#: src/components/learning-center/article-template.tsx:50
 msgid "Back to top"
 msgstr "Vuelve a Inicio"
 
-#: src/components/footer.tsx:46
-#: src/components/header.tsx:93
+#: src/components/footer.tsx:64
+#: src/components/header.tsx:101
 msgid "Contact"
 msgstr "Contacto"
 
-#: src/pages/our-mission.tsx:21
+#: src/pages/our-mission.tsx:19
 msgid "Contact Us"
 msgstr "Contáctanos"
 
-#: src/components/header.tsx:47
+#: src/components/header.tsx:51
 msgid "DEMO SITE"
 msgstr "SITIO DEMO"
 
-#: src/components/footer.tsx:49
-#: src/pages/our-mission.tsx:23
+#: src/components/footer.tsx:69
+#: src/pages/our-mission.tsx:22
 msgid "Donate"
 msgstr "Dona"
 
-#: src/components/footer.tsx:60
-#: src/pages/contact-us.tsx:40
+#: src/components/subscribe.tsx:69
+#: src/pages/contact-us.tsx:39
 msgid "Email Address"
 msgstr "Correo electrónico"
 
-#: src/components/learning-center/all-tools-cta.tsx:19
+#: src/components/learning-center/all-tools-cta.tsx:18
 #: src/pages/index.tsx:19
 #: src/pages/index.tsx:23
 msgid "Enter your address to learn more."
 msgstr "Introduzca su dirección para empezar."
 
-#: src/components/footer.tsx:43
-#: src/components/header.tsx:79
+#: src/components/footer.tsx:59
+#: src/components/header.tsx:84
 msgid "Jobs"
 msgstr "Empleos"
 
-#: src/components/footer.tsx:55
+#: src/components/footer.tsx:76
 msgid "Join our mailing list!"
 msgstr "¡Únete a nuestra lista de correo!"
 
-#: src/components/footer.tsx:24
-#: src/components/header.tsx:89
+#: src/components/footer.tsx:28
+#: src/components/header.tsx:96
 msgid "Learn"
 msgstr "Aprende"
 
-#: src/components/footer.tsx:27
-#: src/components/header.tsx:67
+#: src/components/footer.tsx:33
+#: src/components/header.tsx:72
 msgid "Mission"
 msgstr "Misión"
 
-#: src/components/learning-center/learning-searchbar.tsx:26
+#: src/components/learning-center/learning-searchbar.tsx:32
 msgid "No articles match your search."
 msgstr "No hay resultados coincidan con su búsqueda."
 
-#: src/pages/404.tsx:7
+#: src/pages/404.tsx:8
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/components/footer.tsx:40
-#: src/components/header.tsx:73
+#: src/components/subscribe.tsx:47
+#: src/components/subscribe.tsx:53
+msgid "Oops! A network error occurred. Try again later."
+msgstr ""
+
+#: src/components/subscribe.tsx:42
+msgid "Oops! That email is invalid."
+msgstr ""
+
+#: src/components/footer.tsx:54
+#: src/components/header.tsx:78
 msgid "Partners"
 msgstr "Aliados"
 
-#: src/components/footer.tsx:30
-#: src/components/header.tsx:76
+#: src/components/subscribe.tsx:18
+msgid "Please enter an email address!"
+msgstr ""
+
+#: src/components/footer.tsx:38
+#: src/components/header.tsx:81
 msgid "Press"
 msgstr "Prensa"
 
-#: src/components/footer.tsx:85
+#: src/components/footer.tsx:108
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
-#: src/components/footer.tsx:21
-#: src/components/header.tsx:85
+#: src/components/footer.tsx:23
+#: src/components/header.tsx:91
 msgid "Products"
 msgstr "Herramientas"
 
-#: src/pages/learn.tsx:28
+#: src/pages/learn.tsx:33
 msgid "Read More"
 msgstr "Lee más"
 
-#: src/components/learning-center/all-tools-cta.tsx:19
+#: src/components/learning-center/all-tools-cta.tsx:18
 #: src/pages/index.tsx:23
 msgid "Search address"
 msgstr "Busca dirección"
@@ -129,34 +146,34 @@ msgstr "Busca dirección"
 msgid "Search articles..."
 msgstr "Busca artículos..."
 
-#: src/components/header.tsx:100
 #: src/components/header.tsx:107
+#: src/components/header.tsx:113
 msgid "Sign in"
 msgstr "Inicia sesión"
 
-#: src/components/footer.tsx:64
+#: src/components/subscribe.tsx:73
 #: src/pages/contact-us.tsx:44
 msgid "Sign up"
 msgstr "Únete"
 
-#: src/components/footer.tsx:37
-#: src/components/header.tsx:70
+#: src/components/footer.tsx:49
+#: src/components/header.tsx:75
 msgid "Team"
 msgstr "Equipo"
 
-#: src/components/footer.tsx:88
+#: src/components/footer.tsx:111
 msgid "Terms of use"
 msgstr "Condiciones de Uso"
 
-#: src/components/learning-center/article-template.tsx:97
+#: src/components/learning-center/article-template.tsx:103
 msgid "Updated"
 msgstr "Actualizado"
 
-#: src/components/read-more.tsx:10
+#: src/components/read-more.tsx:11
 msgid "Want to know more?"
 msgstr "¿Quieres saber más?"
 
-#: src/components/learning-center/article-template.tsx:21
+#: src/components/learning-center/article-template.tsx:20
 msgid "Want to take action?"
 msgstr "¿Quieres tomar medidas?"
 
@@ -164,11 +181,10 @@ msgstr "¿Quieres tomar medidas?"
 msgid "What we do"
 msgstr "Lo que hacemos"
 
-#: src/components/learning-center/article-template.tsx:95
+#: src/components/learning-center/article-template.tsx:99
 msgid "Written by"
 msgstr "Escrita por"
 
-#: src/pages/404.tsx:8
+#: src/pages/404.tsx:11
 msgid "You just found a page that doesn't exist... the sadness."
 msgstr "Acabas de llegar a una ruta que no existe... es muy triste."
-

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -33,7 +33,7 @@ msgstr "<0>JustFix.nyc</0> es una organización sin fines de lucro registrada."
 msgid "About us"
 msgstr "Sobre nosotros"
 
-#: src/components/subscribe.tsx:37
+#: src/components/subscribe.tsx:38
 msgid "All set! Thanks for subscribing!"
 msgstr ""
 
@@ -63,8 +63,7 @@ msgstr "SITIO DEMO"
 msgid "Donate"
 msgstr "Dona"
 
-#: src/components/subscribe.tsx:69
-#: src/pages/contact-us.tsx:39
+#: src/components/subscribe.tsx:72
 msgid "Email Address"
 msgstr "Correo electrónico"
 
@@ -101,12 +100,12 @@ msgstr "No hay resultados coincidan con su búsqueda."
 msgid "Not found"
 msgstr "No encontrado"
 
-#: src/components/subscribe.tsx:47
-#: src/components/subscribe.tsx:53
+#: src/components/subscribe.tsx:48
+#: src/components/subscribe.tsx:54
 msgid "Oops! A network error occurred. Try again later."
 msgstr ""
 
-#: src/components/subscribe.tsx:42
+#: src/components/subscribe.tsx:43
 msgid "Oops! That email is invalid."
 msgstr ""
 
@@ -115,7 +114,7 @@ msgstr ""
 msgid "Partners"
 msgstr "Aliados"
 
-#: src/components/subscribe.tsx:18
+#: src/components/subscribe.tsx:19
 msgid "Please enter an email address!"
 msgstr ""
 
@@ -151,8 +150,7 @@ msgstr "Busca artículos..."
 msgid "Sign in"
 msgstr "Inicia sesión"
 
-#: src/components/subscribe.tsx:73
-#: src/pages/contact-us.tsx:44
+#: src/components/subscribe.tsx:76
 msgid "Sign up"
 msgstr "Únete"
 

--- a/src/pages/contact-us.tsx
+++ b/src/pages/contact-us.tsx
@@ -2,86 +2,50 @@ import React from "react";
 import { StaticQuery, graphql } from "gatsby";
 import { SocialIcon } from "react-social-icons";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
-import { t, Trans } from "@lingui/macro";
-import { I18n } from "@lingui/react";
-// import { Link } from 'gatsby'
 
 import "../styles/contact.scss";
 
 import Layout from "../components/layout";
 import { ContentfulContent } from ".";
-
-const MAILCHIMP_URL =
-  "https://nyc.us13.list-manage.com/subscribe/post?u=d4f5d1addd4357eb77c3f8a99&amp;id=588f6c6ef4";
+import Subscribe from "../components/subscribe";
 
 export const ContactPageScaffolding = (props: ContentfulContent) => (
   <Layout metadata={props.content.metadata} locale={props.locale}>
-    <I18n>
-      {({ i18n }) => (
-        <div id="contact" className="contact-page">
-          <section className="hero is-medium">
-            <div className="hero-body has-text-centered is-horizontal-center content-wrapper">
-              <div className="container">
-                <h1 className="title is-size-2 has-text-grey-dark has-text-weight-normal is-spaced">
-                  {props.content.pageTitle}
-                </h1>
-                <span className="is-size-5 has-text-grey-dark">
-                  {documentToReactComponents(props.content.contactCta.json)}
-                </span>
+    <div id="contact" className="contact-page">
+      <section className="hero is-medium">
+        <div className="hero-body has-text-centered is-horizontal-center content-wrapper">
+          <div className="container">
+            <h1 className="title is-size-2 has-text-grey-dark has-text-weight-normal is-spaced">
+              {props.content.pageTitle}
+            </h1>
+            <span className="is-size-5 has-text-grey-dark">
+              {documentToReactComponents(props.content.contactCta.json)}
+            </span>
 
-                <div className="field">
-                  {props.content.socialButtons.map((button: any, i: number) => (
-                    <SocialIcon
-                      key={i}
-                      url={button.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      bgColor="#0096D7"
-                      style={{ height: 40, width: 40 }}
-                    />
-                  ))}
-                </div>
-
-                <h1 className="title is-size-4 has-text-grey-dark is-spaced ">
-                  {props.content.mailingListTitle}
-                </h1>
-                <span className="subtitle has-text-grey-dark">
-                  {props.content.mailingListSubtitle}
-                </span>
-
-                <form
-                  action={MAILCHIMP_URL}
-                  className="email-form is-horizontal-center"
-                  method="post"
+            <div className="field">
+              {props.content.socialButtons.map((button: any, i: number) => (
+                <SocialIcon
+                  key={i}
+                  url={button.url}
                   target="_blank"
-                >
-                  <div className="mc-field-group">
-                    <div className="field has-addons">
-                      <div className="control is-expanded">
-                        <input
-                          type="email"
-                          name="EMAIL"
-                          className="required email input"
-                          id="mce-EMAIL"
-                          placeholder={i18n._(t`Email Address`)}
-                        />
-                      </div>
-                      <div className="control">
-                        <button className="button is-primary" type="submit">
-                          <span className="is-uppercase">
-                            <Trans>Sign up</Trans>
-                          </span>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </form>
-              </div>
+                  rel="noopener noreferrer"
+                  bgColor="#0096D7"
+                  style={{ height: 40, width: 40 }}
+                />
+              ))}
             </div>
-          </section>
+
+            <h1 className="title is-size-4 has-text-grey-dark is-spaced ">
+              {props.content.mailingListTitle}
+            </h1>
+            <span className="subtitle has-text-grey-dark">
+              {props.content.mailingListSubtitle}
+            </span>
+            <Subscribe location="page" />
+          </div>
         </div>
-      )}
-    </I18n>
+      </section>
+    </div>
   </Layout>
 );
 

--- a/src/styles/contact.scss
+++ b/src/styles/contact.scss
@@ -7,6 +7,11 @@
     }
     .email-form {
       max-width: 400px;
+      // Remove bottom margin when field is part of email form
+      // to accomodate response messages that appear below
+      .field {
+        margin-bottom: 1rem;
+      }
     }
   }
 }


### PR DESCRIPTION
This PR replaces our current API for Mailchimp email signups and instead uses the new API endpoint implemented in the Tenant Platform! It also adds some response messages below the email input to properly inform users of the status of their email signup. All is analogous to [this PR on WhoOwnsWhat](https://github.com/JustFixNYC/who-owns-what/pull/288).