### PR TITLE
Make article subtitle text a content block

### DIFF
--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -178,9 +178,9 @@ const LearningArticle = (props: Props) => {
                     </span>
                   </p>
                   {content.subtitle && (
-                    <span className="is-size-6 has-text-grey-dark">
+                    <div className="content is-size-6 has-text-grey-dark">
                       {documentToReactComponents(content.subtitle.json)}
-                    </span>
+                    </div>
                   )}
                 </div>
               </div>


### PR DESCRIPTION
This PR adds the `.content` class to all first blocks of intro text in all Learning center articles. This allows for proper spacing between paragraphs if there happen to be more than one here.