### PR TITLE
Updated eviction moratorium banner

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -35,18 +35,21 @@ const MoratoriumBanner = () => {
           <p>
             <Trans>
               <span className="has-text-weight-bold">COVID-19 Update: </span>
-              JustFix.nyc remains in operation, and we are adapting our products
-              to match new rules put in place during the Covid-19 public health
-              crisis. Thanks to organizing from tenant leaders, renters now have
-              stronger protections during this time, including a full halt on
-              eviction cases.{" "}
+              JustFix.nyc is operating, and has adapted our products to match
+              preliminary rules put in place during the COVID-19 crisis. While
+              NYC is in Phase 2, we still recommend full precautions. Thanks to
+              tenant organizing during this time, renters cannot be evicted for
+              any reason until August 6. Visit{" "}
               <a
-                href="https://www.righttocounselnyc.org/moratorium_faq"
+                href="https://www.righttocounselnyc.org/ny_eviction_moratorium_faq"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                <span className="has-text-weight-bold">Learn more</span>
-              </a>
+                <span className="has-text-weight-bold">
+                  Right to Council’s Eviction Moratorium FAQs
+                </span>
+              </a>{" "}
+              to learn more.
             </Trans>
           </p>
         </div>


### PR DESCRIPTION
This hotfix updates the COVID-19 info banner on the home page with more up-to-date info.

