### PR TITLE
Sort article previews on LC category pages by `dateUpdated`

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -95,8 +95,15 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
 
   const articlePreviews = data.contentfulLearningCenterSearchPage.articles.map(
     (article) => {
-      const { title, slug, previewText, categories, ...rest } = article;
-      const subset = { title, slug, previewText, categories };
+      const {
+        title,
+        slug,
+        previewText,
+        categories,
+        dateUpdated,
+        ...rest
+      } = article;
+      const subset = { title, slug, previewText, categories, dateUpdated };
       return subset;
     }
   );

--- a/src/components/learning-center/category-page-template.tsx
+++ b/src/components/learning-center/category-page-template.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Layout from "../layout";
-import { ArticlePreviewCard } from "../../pages/learn";
+import { ArticlePreviewCard, sortArticlesByDate } from "../../pages/learn";
 import { Link } from "gatsby";
 import { ThankYouBanner } from "./thank-you-banner";
 import CategoryMenu from "./category-menu";
@@ -73,13 +73,15 @@ const LearningCategoryPage = (props: Props) => {
         </section>
         <section className="content-wrapper tight">
           {articlePreviews && articlePreviews.length > 0 ? (
-            articlePreviews.map((article: any, i: number) => (
-              <ArticlePreviewCard
-                articleData={article}
-                key={i}
-                locale={props.pageContext.locale}
-              />
-            ))
+            articlePreviews
+              .sort(sortArticlesByDate)
+              .map((article: any, i: number) => (
+                <ArticlePreviewCard
+                  articleData={article}
+                  key={i}
+                  locale={props.pageContext.locale}
+                />
+              ))
           ) : (
             <NoArticlesYet />
           )}

--- a/src/pages/learn.tsx
+++ b/src/pages/learn.tsx
@@ -13,7 +13,7 @@ import classnames from "classnames";
 
 const widont = require("widont");
 
-const sortArticlesByDate = (article1: any, article2: any) => {
+export const sortArticlesByDate = (article1: any, article2: any) => {
   const date1 = new Date(article1.dateUpdated).getTime();
   const date2 = new Date(article2.dateUpdated).getTime();
   return date2 - date1;


### PR DESCRIPTION
This PR extends our current system for sorting article previews to all of the category pages of the Learning Center. Now, those previews (as well as on the home page for LC) sort by date last updated.