### PR TITLE
Updated messages.po with spanish translation of covid banner

### DIFF
--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #: src/components/header.tsx:15
-msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
+msgid "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
 msgstr ""
 
 #: src/components/footer.tsx:93
@@ -26,7 +26,7 @@ msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr ""
 
 #: src/components/footer.tsx:45
-#: src/components/header.tsx:67
+#: src/components/header.tsx:70
 msgid "About us"
 msgstr ""
 
@@ -43,7 +43,7 @@ msgid "Back to top"
 msgstr ""
 
 #: src/components/footer.tsx:64
-#: src/components/header.tsx:101
+#: src/components/header.tsx:104
 msgid "Contact"
 msgstr ""
 
@@ -51,7 +51,7 @@ msgstr ""
 msgid "Contact Us"
 msgstr ""
 
-#: src/components/header.tsx:51
+#: src/components/header.tsx:54
 msgid "DEMO SITE"
 msgstr ""
 
@@ -71,7 +71,7 @@ msgid "Enter your address to learn more."
 msgstr ""
 
 #: src/components/footer.tsx:59
-#: src/components/header.tsx:84
+#: src/components/header.tsx:87
 msgid "Jobs"
 msgstr ""
 
@@ -80,12 +80,12 @@ msgid "Join our mailing list!"
 msgstr ""
 
 #: src/components/footer.tsx:28
-#: src/components/header.tsx:96
+#: src/components/header.tsx:99
 msgid "Learn"
 msgstr ""
 
 #: src/components/footer.tsx:33
-#: src/components/header.tsx:72
+#: src/components/header.tsx:75
 msgid "Mission"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgid "Oops! That email is invalid."
 msgstr ""
 
 #: src/components/footer.tsx:54
-#: src/components/header.tsx:78
+#: src/components/header.tsx:81
 msgid "Partners"
 msgstr ""
 
@@ -116,7 +116,7 @@ msgid "Please enter an email address!"
 msgstr ""
 
 #: src/components/footer.tsx:38
-#: src/components/header.tsx:81
+#: src/components/header.tsx:84
 msgid "Press"
 msgstr ""
 
@@ -125,7 +125,7 @@ msgid "Privacy policy"
 msgstr ""
 
 #: src/components/footer.tsx:23
-#: src/components/header.tsx:91
+#: src/components/header.tsx:94
 msgid "Products"
 msgstr ""
 
@@ -142,8 +142,8 @@ msgstr ""
 msgid "Search articles..."
 msgstr ""
 
-#: src/components/header.tsx:107
-#: src/components/header.tsx:113
+#: src/components/header.tsx:110
+#: src/components/header.tsx:116
 msgid "Sign in"
 msgstr ""
 
@@ -152,7 +152,7 @@ msgid "Sign up"
 msgstr ""
 
 #: src/components/footer.tsx:49
-#: src/components/header.tsx:75
+#: src/components/header.tsx:78
 msgid "Team"
 msgstr ""
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -17,8 +17,8 @@ msgstr ""
 "X-Crowdin-File: /master/src/locales/en/messages.po\n"
 
 #: src/components/header.tsx:15
-msgid "<0>COVID-19 Update: </0>JustFix.nyc remains in operation, and we are adapting our products to match new rules put in place during the Covid-19 public health crisis. Thanks to organizing from tenant leaders, renters now have stronger protections during this time, including a full halt on eviction cases. <1><2>Learn more</2></1>"
-msgstr ""
+msgid "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
+msgstr "<0>Actualización COVID-19: </0>JustFix.nyc está operativo, y hemos adaptado nuestros productos a las normas establecidas durante la crisis de COVID-19. Todavía recomendamos que se tomen todas las precauciones posibles para mantenerse sanos durante esta crisis de salud pública. Gracias al poder de la organización de inquilinos, los inquilinos no pueden ser desalojados por ninguna razón. Visita las <1><2>Preguntas Más Frecuentes sobre la Moratoria de Desalojo del Right to Council</2></1> para obtener más información."
 
 #: src/components/footer.tsx:93
 msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
@@ -29,7 +29,7 @@ msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr "<0>JustFix.nyc</0> es una organización sin fines de lucro registrada."
 
 #: src/components/footer.tsx:45
-#: src/components/header.tsx:67
+#: src/components/header.tsx:70
 msgid "About us"
 msgstr "Sobre nosotros"
 
@@ -46,7 +46,7 @@ msgid "Back to top"
 msgstr "Vuelve a Inicio"
 
 #: src/components/footer.tsx:64
-#: src/components/header.tsx:101
+#: src/components/header.tsx:104
 msgid "Contact"
 msgstr "Contacto"
 
@@ -54,7 +54,7 @@ msgstr "Contacto"
 msgid "Contact Us"
 msgstr "Contáctanos"
 
-#: src/components/header.tsx:51
+#: src/components/header.tsx:54
 msgid "DEMO SITE"
 msgstr "SITIO DEMO"
 
@@ -74,7 +74,7 @@ msgid "Enter your address to learn more."
 msgstr "Introduzca su dirección para empezar."
 
 #: src/components/footer.tsx:59
-#: src/components/header.tsx:84
+#: src/components/header.tsx:87
 msgid "Jobs"
 msgstr "Empleos"
 
@@ -83,12 +83,12 @@ msgid "Join our mailing list!"
 msgstr "¡Únete a nuestra lista de correo!"
 
 #: src/components/footer.tsx:28
-#: src/components/header.tsx:96
+#: src/components/header.tsx:99
 msgid "Learn"
 msgstr "Aprende"
 
 #: src/components/footer.tsx:33
-#: src/components/header.tsx:72
+#: src/components/header.tsx:75
 msgid "Mission"
 msgstr "Misión"
 
@@ -110,7 +110,7 @@ msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
 #: src/components/footer.tsx:54
-#: src/components/header.tsx:78
+#: src/components/header.tsx:81
 msgid "Partners"
 msgstr "Aliados"
 
@@ -119,7 +119,7 @@ msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
 #: src/components/footer.tsx:38
-#: src/components/header.tsx:81
+#: src/components/header.tsx:84
 msgid "Press"
 msgstr "Prensa"
 
@@ -128,7 +128,7 @@ msgid "Privacy policy"
 msgstr "Política de privacidad"
 
 #: src/components/footer.tsx:23
-#: src/components/header.tsx:91
+#: src/components/header.tsx:94
 msgid "Products"
 msgstr "Herramientas"
 
@@ -145,8 +145,8 @@ msgstr "Busca dirección"
 msgid "Search articles..."
 msgstr "Busca artículos..."
 
-#: src/components/header.tsx:107
-#: src/components/header.tsx:113
+#: src/components/header.tsx:110
+#: src/components/header.tsx:116
 msgid "Sign in"
 msgstr "Inicia sesión"
 
@@ -155,7 +155,7 @@ msgid "Sign up"
 msgstr "Únete"
 
 #: src/components/footer.tsx:49
-#: src/components/header.tsx:75
+#: src/components/header.tsx:78
 msgid "Team"
 msgstr "Equipo"
 

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -26,7 +26,6 @@
         a {
           color: inherit;
           text-decoration: underline;
-          white-space: nowrap;
 
           &:hover {
             text-decoration: none;


### PR DESCRIPTION
This PR updates our translation files so that we now pull the appropriate Spanish translation of the Eviction Moratorium banner.