### PR TITLE
Add vscode devcontainer setup.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/docker-existing-dockerfile
+{
+	"name": "JustFix.nyc Website VSCode development container",
+	"image": "node:10",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": null,
+		// This is where the virtual environment set up by our Docker Compose config is located.
+		"[typescriptreact]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[typescript]": {
+			"editor.tabSize": 2,
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[json]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+		"[javascript]": {
+			"editor.defaultFormatter": "esbenp.prettier-vscode"
+		},
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"esbenp.prettier-vscode",
+		"dbaeumer.vscode-eslint",
+	],
+
+	"mounts": [
+		// These mounts will ensure that the volumes our Docker Compose setup uses
+		// (see `docker-compose.yml`) will be reused by VSCode.  Note that these
+		// rely on the project to be cloned in a folder called `justfix-website`, since
+		// Docker Compose prefixes the volumes it creates with this directory name.
+		"source=justfix-website_node-modules,target=/workspaces/justfix-website/node_modules/,type=volume"
+	],
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 # Yikes! Don't go in there!
 node_modules
 src/locales
+.devcontainer
 
 .cache
 .circleci


### PR DESCRIPTION
As we've done with who-owns-what and tenants2, this adds a `.devcontainer` folder to make it easy to configure VSCode for development of this site.