### PR TITLE
Added Lingui translation for "Sections" on article pages

### DIFF
--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -108,7 +108,9 @@ const LearningArticle = (props: Props) => {
       id="navmenu"
       className={"menu " + ((props && props.styleClass) || "")}
     >
-      <p className="menu-label">Sections</p>
+      <p className="menu-label">
+        <Trans>Sections</Trans>
+      </p>
       <ul className="menu-list">
         {content.articleSections.map((articleSection: any, i: number) =>
           articleSection.__typename === "ContentfulLearningArticleSection" ? (

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -15,171 +15,175 @@ msgstr ""
 
 #: src/components/header.tsx:15
 msgid "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
-msgstr ""
+msgstr "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
 
 #: src/components/footer.tsx:93
 msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
-msgstr ""
+msgstr "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
 #: src/components/footer.tsx:102
 msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
-msgstr ""
+msgstr "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 
 #: src/components/footer.tsx:45
 #: src/components/header.tsx:70
 msgid "About us"
-msgstr ""
+msgstr "About us"
 
 #: src/components/subscribe.tsx:38
 msgid "All set! Thanks for subscribing!"
-msgstr ""
+msgstr "All set! Thanks for subscribing!"
 
-#: src/components/learning-center/category-page-template.tsx:32
+#: src/components/learning-center/category-page-template.tsx:30
 msgid "Back to Overview"
-msgstr ""
+msgstr "Back to Overview"
 
 #: src/components/learning-center/article-template.tsx:50
 msgid "Back to top"
-msgstr ""
+msgstr "Back to top"
 
 #: src/components/footer.tsx:64
 #: src/components/header.tsx:104
 msgid "Contact"
-msgstr ""
+msgstr "Contact"
 
-#: src/pages/our-mission.tsx:19
+#: src/pages/our-mission.en.tsx:19
 msgid "Contact Us"
-msgstr ""
+msgstr "Contact Us"
 
 #: src/components/header.tsx:54
 msgid "DEMO SITE"
-msgstr ""
+msgstr "DEMO SITE"
 
 #: src/components/footer.tsx:69
-#: src/pages/our-mission.tsx:22
+#: src/pages/our-mission.en.tsx:22
 msgid "Donate"
-msgstr ""
+msgstr "Donate"
 
 #: src/components/subscribe.tsx:72
 msgid "Email Address"
-msgstr ""
+msgstr "Email Address"
 
 #: src/components/learning-center/all-tools-cta.tsx:18
-#: src/pages/index.tsx:19
-#: src/pages/index.tsx:23
+#: src/pages/index.en.tsx:19
+#: src/pages/index.en.tsx:23
 msgid "Enter your address to learn more."
-msgstr ""
+msgstr "Enter your address to learn more."
 
 #: src/components/footer.tsx:59
 #: src/components/header.tsx:87
 msgid "Jobs"
-msgstr ""
+msgstr "Jobs"
 
 #: src/components/footer.tsx:76
 msgid "Join our mailing list!"
-msgstr ""
+msgstr "Join our mailing list!"
 
 #: src/components/footer.tsx:28
 #: src/components/header.tsx:99
 msgid "Learn"
-msgstr ""
+msgstr "Learn"
 
 #: src/components/footer.tsx:33
 #: src/components/header.tsx:75
 msgid "Mission"
-msgstr ""
+msgstr "Mission"
 
 #: src/components/learning-center/learning-searchbar.tsx:32
 msgid "No articles match your search."
-msgstr ""
+msgstr "No articles match your search."
 
 #: src/pages/404.tsx:8
 msgid "Not found"
-msgstr ""
+msgstr "Not found"
 
 #: src/components/subscribe.tsx:48
 #: src/components/subscribe.tsx:54
 msgid "Oops! A network error occurred. Try again later."
-msgstr ""
+msgstr "Oops! A network error occurred. Try again later."
 
 #: src/components/subscribe.tsx:43
 msgid "Oops! That email is invalid."
-msgstr ""
+msgstr "Oops! That email is invalid."
 
 #: src/components/footer.tsx:54
 #: src/components/header.tsx:81
 msgid "Partners"
-msgstr ""
+msgstr "Partners"
 
 #: src/components/subscribe.tsx:19
 msgid "Please enter an email address!"
-msgstr ""
+msgstr "Please enter an email address!"
 
 #: src/components/footer.tsx:38
 #: src/components/header.tsx:84
 msgid "Press"
-msgstr ""
+msgstr "Press"
 
 #: src/components/footer.tsx:108
 msgid "Privacy policy"
-msgstr ""
+msgstr "Privacy policy"
 
 #: src/components/footer.tsx:23
 #: src/components/header.tsx:94
 msgid "Products"
-msgstr ""
+msgstr "Products"
 
-#: src/pages/learn.tsx:33
+#: src/pages/learn.en.tsx:33
 msgid "Read More"
-msgstr ""
+msgstr "Read More"
 
 #: src/components/learning-center/all-tools-cta.tsx:18
-#: src/pages/index.tsx:23
+#: src/pages/index.en.tsx:23
 msgid "Search address"
-msgstr ""
+msgstr "Search address"
 
 #: src/components/learning-center/learning-searchbar.tsx:13
 msgid "Search articles..."
-msgstr ""
+msgstr "Search articles..."
+
+#: src/components/learning-center/article-template.tsx:59
+msgid "Sections"
+msgstr "Sections"
 
 #: src/components/header.tsx:110
 #: src/components/header.tsx:116
 msgid "Sign in"
-msgstr ""
+msgstr "Sign in"
 
 #: src/components/subscribe.tsx:76
 msgid "Sign up"
-msgstr ""
+msgstr "Sign up"
 
 #: src/components/footer.tsx:49
 #: src/components/header.tsx:78
 msgid "Team"
-msgstr ""
+msgstr "Team"
 
 #: src/components/footer.tsx:111
 msgid "Terms of use"
-msgstr ""
+msgstr "Terms of use"
 
 #: src/components/learning-center/article-template.tsx:103
 msgid "Updated"
-msgstr ""
+msgstr "Updated"
 
 #: src/components/read-more.tsx:11
 msgid "Want to know more?"
-msgstr ""
+msgstr "Want to know more?"
 
 #: src/components/learning-center/article-template.tsx:20
 msgid "Want to take action?"
-msgstr ""
+msgstr "Want to take action?"
 
 #: src/components/footer.tsx:19
 msgid "What we do"
-msgstr ""
+msgstr "What we do"
 
 #: src/components/learning-center/article-template.tsx:99
 msgid "Written by"
-msgstr ""
+msgstr "Written by"
 
 #: src/pages/404.tsx:11
 msgid "You just found a page that doesn't exist... the sadness."
-msgstr ""
+msgstr "You just found a page that doesn't exist... the sadness."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -37,7 +37,7 @@ msgstr "Sobre nosotros"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: src/components/learning-center/category-page-template.tsx:32
+#: src/components/learning-center/category-page-template.tsx:30
 msgid "Back to Overview"
 msgstr "Vuelve a Vista General"
 
@@ -50,7 +50,7 @@ msgstr "Vuelve a Inicio"
 msgid "Contact"
 msgstr "Contacto"
 
-#: src/pages/our-mission.tsx:19
+#: src/pages/our-mission.en.tsx:19
 msgid "Contact Us"
 msgstr "Contáctanos"
 
@@ -59,7 +59,7 @@ msgid "DEMO SITE"
 msgstr "SITIO DEMO"
 
 #: src/components/footer.tsx:69
-#: src/pages/our-mission.tsx:22
+#: src/pages/our-mission.en.tsx:22
 msgid "Donate"
 msgstr "Dona"
 
@@ -68,8 +68,8 @@ msgid "Email Address"
 msgstr "Correo electrónico"
 
 #: src/components/learning-center/all-tools-cta.tsx:18
-#: src/pages/index.tsx:19
-#: src/pages/index.tsx:23
+#: src/pages/index.en.tsx:19
+#: src/pages/index.en.tsx:23
 msgid "Enter your address to learn more."
 msgstr "Introduzca su dirección para empezar."
 
@@ -132,18 +132,22 @@ msgstr "Política de privacidad"
 msgid "Products"
 msgstr "Herramientas"
 
-#: src/pages/learn.tsx:33
+#: src/pages/learn.en.tsx:33
 msgid "Read More"
 msgstr "Lee más"
 
 #: src/components/learning-center/all-tools-cta.tsx:18
-#: src/pages/index.tsx:23
+#: src/pages/index.en.tsx:23
 msgid "Search address"
 msgstr "Busca dirección"
 
 #: src/components/learning-center/learning-searchbar.tsx:13
 msgid "Search articles..."
 msgstr "Busca artículos..."
+
+#: src/components/learning-center/article-template.tsx:59
+msgid "Sections"
+msgstr ""
 
 #: src/components/header.tsx:110
 #: src/components/header.tsx:116

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -147,7 +147,7 @@ msgstr "Busca artículos..."
 
 #: src/components/learning-center/article-template.tsx:59
 msgid "Sections"
-msgstr ""
+msgstr "Secciones"
 
 #: src/components/header.tsx:110
 #: src/components/header.tsx:116


### PR DESCRIPTION
This Hot Fix adds in a missing translation to our Learning Center article pages. It also adds in our "English" translations inline to fix an issue where English translations were marked as "missing" when running Lingui commands.