### PR TITLE
Added feature flag for i18n redirects

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -44,6 +44,15 @@ SITE_URL=
 
 GATSBY_DEMO_SITE=
 
+## ENABLE PUBLIC FACING I18N (Feature Flag, Optional)
+## 
+## Setting ENABLE PUBLIC FACING I18N to 1 will allow our locale-redirect.tsx component
+## to redirect users to any accepted locale defined in locale-config.json. If not set to 1,
+## localized pages of all languages will still be accessible but there will not exist any links
+## or redirects to them on the site.
+
+GATSBY_ENABLE_PUBLIC_FACING_I18N=
+
 # =========================
 # TENANT PLATFORM SITE ORIGIN (OPTIONAL)
 # =========================

--- a/src/components/locale-redirect.tsx
+++ b/src/components/locale-redirect.tsx
@@ -14,7 +14,7 @@ const allowRedirects = process.env.GATSBY_ENABLE_PUBLIC_FACING_I18N === "1";
 
 const getRedirectLanguage = (
   defaultLocale: string,
-  acceptedLocales: string[],
+  acceptedLocales: string[]
 ) => {
   if (typeof navigator === `undefined`) {
     return defaultLocale;
@@ -40,7 +40,7 @@ const LocaleRedirectPage = (props: Props) => {
   const urlLang = allowRedirects
     ? getRedirectLanguage(
         props.pageContext.defaultLocale,
-        props.pageContext.acceptedLocales,
+        props.pageContext.acceptedLocales
       )
     : props.pageContext.defaultLocale;
   const redirectURL = `/${urlLang}${props.pageContext.slug}`;

--- a/src/components/locale-redirect.tsx
+++ b/src/components/locale-redirect.tsx
@@ -10,9 +10,11 @@ import "../styles/locale-redirect.scss";
 // Adapted from this very useful StackOverflow post:
 // https://stackoverflow.com/questions/59908989/redirect-based-on-browser-language-in-gatsby
 
+const allowRedirects = process.env.GATSBY_ENABLE_PUBLIC_FACING_I18N === "1";
+
 const getRedirectLanguage = (
   defaultLocale: string,
-  acceptedLocales: string[]
+  acceptedLocales: string[],
 ) => {
   if (typeof navigator === `undefined`) {
     return defaultLocale;
@@ -35,10 +37,12 @@ type Props = {
 };
 
 const LocaleRedirectPage = (props: Props) => {
-  const urlLang = getRedirectLanguage(
-    props.pageContext.defaultLocale,
-    props.pageContext.acceptedLocales
-  );
+  const urlLang = allowRedirects
+    ? getRedirectLanguage(
+        props.pageContext.defaultLocale,
+        props.pageContext.acceptedLocales,
+      )
+    : props.pageContext.defaultLocale;
   const redirectURL = `/${urlLang}${props.pageContext.slug}`;
 
   useEffect(() => {


### PR DESCRIPTION
This quick PR adds a feature flag that we can use to turn on redirection to any of our locales vs just our default locale of "en"