### PR TITLE
Factor out a <LocaleLink> component.

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,21 +1,19 @@
 import React from "react";
 import { SocialIcon } from "react-social-icons";
-import { Link } from "gatsby";
 import { Trans } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 
 import "../styles/footer.scss";
 import { Locale } from "../pages/index.en";
 import Subscribe from "./subscribe";
+import { LocaleLink as Link } from "./locale-link";
 
 const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
-  const localePrefix = "/" + locale;
-
   return (
     <div className="footer has-background-info">
       <div className="columns has-text-centered-touch is-desktop">
         <div className="column">
-          <Link to={localePrefix + "/"} className="button is-info">
+          <Link to="/" className="button is-info">
             <img src={require("../img/brand/logo.png")} alt="JustFix.nyc" />
           </Link>
         </div>
@@ -25,7 +23,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </p>
           <Link
             className="link has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/#products"}
+            to="/#products"
           >
             <p>
               <Trans>Products</Trans>
@@ -33,7 +31,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </Link>
           <Link
             className="link has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/learn"}
+            to="/learn"
           >
             <p>
               <Trans>Learn</Trans>
@@ -41,7 +39,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </Link>
           <Link
             className="link has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/our-mission"}
+            to="/our-mission"
           >
             <p>
               <Trans>Mission</Trans>
@@ -49,7 +47,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </Link>
           <Link
             className="link has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/about/press"}
+            to="/about/press"
           >
             <p>
               <Trans>Press</Trans>
@@ -63,7 +61,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </p>
           <Link
             className="link has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/about/team"}
+            to="/about/team"
           >
             <p>
               <Trans>Team</Trans>
@@ -71,7 +69,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </Link>
           <Link
             className="link has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/about/partners"}
+            to="/about/partners"
           >
             <p>
               <Trans>Partners</Trans>
@@ -89,7 +87,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </a>
           <Link
             className="link has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/contact-us"}
+            to="/contact-us"
           >
             <p>
               <Trans>Contact</Trans>
@@ -166,13 +164,13 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           </p>
           <Link
             className="link legal is-inline-block has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/privacy-policy"}
+            to="/privacy-policy"
           >
             <Trans>Privacy policy</Trans>
           </Link>
           <Link
             className="link legal is-inline-block has-text-weight-semibold is-uppercase"
-            to={localePrefix + "/terms-of-use"}
+            to="/terms-of-use"
           >
             <Trans>Terms of use</Trans>
           </Link>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from "react";
-import { Link } from "gatsby";
 import { Trans } from "@lingui/macro";
 
 import "../styles/header.scss";
-import { useCurrentLocale } from "../util/use-locale";
+import { LocaleLink as Link } from "../components/locale-link";
 
 const isDemoSite = process.env.GATSBY_DEMO_SITE === "1";
 
@@ -54,7 +53,6 @@ const Header: React.FC<{
   isLandingPage?: boolean;
 }> = ({ isLandingPage }) => {
   const [burgerMenuIsOpen, setBurgerMenuStatus] = useState(false);
-  const localePrefix = "/" + useCurrentLocale();
 
   return (
     <div className={"header " + (isLandingPage && "is-absolute")}>
@@ -65,7 +63,7 @@ const Header: React.FC<{
         aria-label="main navigation"
       >
         <div className="navbar-brand">
-          <Link to={localePrefix + "/"} className="navbar-item">
+          <Link to="/" className="navbar-item">
             <img
               src={require("../img/brand/logo.png")}
               width="112"
@@ -112,25 +110,16 @@ const Header: React.FC<{
               </a>
 
               <div className="navbar-dropdown">
-                <Link
-                  to={localePrefix + "/our-mission"}
-                  className="navbar-item"
-                >
+                <Link to="/our-mission" className="navbar-item">
                   <Trans>Mission</Trans>
                 </Link>
-                <Link to={localePrefix + "/about/team"} className="navbar-item">
+                <Link to="/about/team" className="navbar-item">
                   <Trans>Team</Trans>
                 </Link>
-                <Link
-                  to={localePrefix + "/about/partners"}
-                  className="navbar-item"
-                >
+                <Link to="/about/partners" className="navbar-item">
                   <Trans>Partners</Trans>
                 </Link>
-                <Link
-                  to={localePrefix + "/about/press"}
-                  className="navbar-item"
-                >
+                <Link to="/about/press" className="navbar-item">
                   <Trans>Press</Trans>
                 </Link>
                 <a
@@ -145,7 +134,7 @@ const Header: React.FC<{
             </div>
 
             <Link
-              to={localePrefix + "/#products"}
+              to="/#products"
               className={
                 "navbar-item is-uppercase has-text-" +
                 (burgerMenuIsOpen ? "black" : "white")
@@ -155,7 +144,7 @@ const Header: React.FC<{
             </Link>
 
             <Link
-              to={localePrefix + "/learn"}
+              to="/learn"
               className={
                 "navbar-item is-uppercase has-text-" +
                 (burgerMenuIsOpen ? "black" : "white")
@@ -165,7 +154,7 @@ const Header: React.FC<{
             </Link>
 
             <Link
-              to={localePrefix + "/contact-us"}
+              to="/contact-us"
               className={
                 "navbar-item is-uppercase has-text-" +
                 (burgerMenuIsOpen ? "black" : "white")

--- a/src/components/learning-center/article-footer.tsx
+++ b/src/components/learning-center/article-footer.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Link } from "gatsby";
-import { ContentfulContent, Locale } from "../../pages/index.en";
+import { ContentfulContent } from "../../pages/index.en";
 import { Category } from "../../pages/learn.en";
+import { LocaleLink } from "../locale-link";
 
 const widont = require("widont");
 
@@ -16,20 +16,19 @@ type TableOfContentsSection = {
   categoryTitle: string;
   articles: ArticleListing[];
   noDivider?: boolean;
-} & Locale;
+};
 
 const TableOfContentsSection = (props: TableOfContentsSection) => {
-  const localePrefix = "/" + props.locale;
   return props.articles.length > 0 ? (
     <div className="table-of-contents-section">
       <p className="menu-label">{props.categoryTitle}</p>
       <ul>
         {props.articles.map((article: ArticleListing, i: number) => (
           <li key={i}>
-            <Link to={localePrefix + "/learn/" + article.slug}>
+            <LocaleLink to={"/learn/" + article.slug}>
               {" "}
               {article.title}{" "}
-            </Link>
+            </LocaleLink>
           </li>
         ))}
         <div
@@ -44,8 +43,16 @@ const TableOfContentsSection = (props: TableOfContentsSection) => {
   );
 };
 
-const FooterCta = (props: any) => {
-  const localePrefix = props.locale ? "/" + props.locale : "";
+type FooterCtaProps = {
+  content: {
+    title: string;
+    subtitle: string;
+    ctaLink: string;
+    ctaText: string;
+  };
+};
+
+const FooterCta = (props: FooterCtaProps) => {
   return (
     <div className="hero footer-cta is-white-ter">
       <div className="hero-body">
@@ -57,15 +64,15 @@ const FooterCta = (props: any) => {
             {widont(props.content.subtitle)}
           </p>
         )}
-        <Link to={localePrefix + props.content.ctaLink}>
+        <LocaleLink to={props.content.ctaLink}>
           {props.content.ctaText} →
-        </Link>
+        </LocaleLink>
       </div>
     </div>
   );
 };
 
-export const LearningArticleFooter = (props: ContentfulContent & Locale) => {
+export const LearningArticleFooter = (props: ContentfulContent) => {
   const AllArticles = props.content.articles;
   const ArticlesSortedByCategory = props.content.categoryButtons.map(
     (category: Category) => ({
@@ -84,11 +91,8 @@ export const LearningArticleFooter = (props: ContentfulContent & Locale) => {
   return (
     <div className="columns is-desktop has-background-white-ter">
       <div className="column footer-ctas">
-        <FooterCta
-          locale={props.locale}
-          content={props.content.learningCenterCta}
-        />
-        <FooterCta locale={props.locale} content={props.content.justFixCta} />
+        <FooterCta content={props.content.learningCenterCta} />
+        <FooterCta content={props.content.justFixCta} />
       </div>
       <div className="column table-of-contents is-half-desktop">
         <div className="columns hero-body">
@@ -98,7 +102,6 @@ export const LearningArticleFooter = (props: ContentfulContent & Locale) => {
                 i % NUM_COLUMNS === 0 ? (
                   <TableOfContentsSection
                     key={i}
-                    locale={props.locale}
                     noDivider={ArticlesSortedByCategory.length <= i + 3}
                     categoryTitle={section.categoryTitle}
                     articles={section.articles}
@@ -114,7 +117,6 @@ export const LearningArticleFooter = (props: ContentfulContent & Locale) => {
                 i % NUM_COLUMNS === 1 ? (
                   <TableOfContentsSection
                     key={i}
-                    locale={props.locale}
                     noDivider={ArticlesSortedByCategory.length <= i + 3}
                     categoryTitle={section.categoryTitle}
                     articles={section.articles}
@@ -130,7 +132,6 @@ export const LearningArticleFooter = (props: ContentfulContent & Locale) => {
                 i % NUM_COLUMNS === 2 ? (
                   <TableOfContentsSection
                     key={i}
-                    locale={props.locale}
                     noDivider={ArticlesSortedByCategory.length <= i + 3}
                     categoryTitle={section.categoryTitle}
                     articles={section.articles}

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { LearningArticleFooter } from "./article-footer";
 import Layout from "../layout";
-import { Link } from "gatsby";
 import { Link as ScrollLink } from "react-scroll";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 
@@ -9,6 +8,7 @@ import "../../styles/learn.scss";
 import { AllToolsCta } from "./all-tools-cta";
 import { Locale } from "../../pages/index.en";
 import { Trans } from "@lingui/macro";
+import { LocaleLink } from "../locale-link";
 
 const widont = require("widont");
 
@@ -100,7 +100,6 @@ function renderSection(articleSection: any, i: number): JSX.Element {
 }
 
 const LearningArticle = (props: Props) => {
-  const localePrefix = "/" + props.pageContext.locale;
   const content = props.pageContext.content;
 
   const NavMenu = (props?: navMenuProps) => (
@@ -146,21 +145,18 @@ const LearningArticle = (props: Props) => {
                 <nav className="breadcrumb" aria-label="breadcrumbs">
                   <ul>
                     <li>
-                      <Link to={localePrefix + "/learn/"}>
+                      <LocaleLink to="/learn/">
                         {props.pageContext.learningCenterTitle}
-                      </Link>
+                      </LocaleLink>
                     </li>
                     <li>
-                      <Link
+                      <LocaleLink
                         to={
-                          localePrefix +
-                          "/learn/category/" +
-                          content.categories[0].slug +
-                          "/"
+                          "/learn/category/" + content.categories[0].slug + "/"
                         }
                       >
                         {content.categories[0].title}
-                      </Link>
+                      </LocaleLink>
                     </li>
                   </ul>
                 </nav>

--- a/src/components/learning-center/category-menu.tsx
+++ b/src/components/learning-center/category-menu.tsx
@@ -1,21 +1,20 @@
 import React from "react";
-import { Link } from "gatsby";
-import { ContentfulContent, Locale } from "../../pages/index.en";
+import { ContentfulContent } from "../../pages/index.en";
 import { Category, isCovidRelated } from "../../pages/learn.en";
 import classnames from "classnames";
+import { LocaleLink } from "../locale-link";
 
 type CategoryMenuProps = ContentfulContent & {
   selectedCategory?: any;
-} & Locale;
+};
 
 const CategoryMenu = (props: CategoryMenuProps) => {
-  const localePrefix = "/" + props.locale;
   return (
     <div className="field is-centered is-hidden-mobile">
       {props.content.map((category: Category, i: number) => (
-        <Link
+        <LocaleLink
           key={i}
-          to={localePrefix + "/learn/category/" + category.slug}
+          to={"/learn/category/" + category.slug}
           className={classnames(
             "button",
             "is-uppercase",
@@ -29,7 +28,7 @@ const CategoryMenu = (props: CategoryMenuProps) => {
           )}
         >
           {category.title}
-        </Link>
+        </LocaleLink>
       ))}
     </div>
   );

--- a/src/components/learning-center/category-page-template.tsx
+++ b/src/components/learning-center/category-page-template.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import Layout from "../layout";
 import { ArticlePreviewCard, sortArticlesByDate } from "../../pages/learn.en";
-import { Link } from "gatsby";
 import { ThankYouBanner } from "./thank-you-banner";
 import CategoryMenu from "./category-menu";
 import { Locale } from "../../pages/index.en";
 import { Trans } from "@lingui/macro";
+import { LocaleLink } from "../locale-link";
 
 const widont = require("widont");
 
@@ -34,7 +34,6 @@ const NoArticlesYet = () => (
 );
 
 const LearningCategoryPage = (props: Props) => {
-  const localePrefix = "/" + props.pageContext.locale;
   const content = props.pageContext.content;
   const articlePreviews = props.pageContext.articlePreviews;
   return (
@@ -45,12 +44,9 @@ const LearningCategoryPage = (props: Props) => {
       <div className="category-page">
         <section className="hero is-small">
           <div className="content-wrapper tight back-to-overview">
-            <Link
-              to={localePrefix + "/learn"}
-              className="has-text-weight-semibold"
-            >
+            <LocaleLink to="/learn" className="has-text-weight-semibold">
               ← <Trans>Back to Overview</Trans>
-            </Link>
+            </LocaleLink>
           </div>
 
           <div className="hero-body has-text-centered is-horizontal-center">

--- a/src/components/learning-center/learning-searchbar.tsx
+++ b/src/components/learning-center/learning-searchbar.tsx
@@ -8,11 +8,11 @@ import {
   connectHits,
   Hits,
 } from "react-instantsearch-dom";
-import { Link } from "gatsby";
 import { SearchBoxExposed } from "react-instantsearch-core";
 import { Locale } from "../../pages/index.en";
 import { I18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
+import { LocaleLink } from "../locale-link";
 
 const appId = process.env.GATSBY_ALGOLIA_APP_ID;
 const searchKey = process.env.GATSBY_ALGOLIA_SEARCH_KEY;
@@ -45,14 +45,21 @@ const SearchBox = ({ currentRefinement, refine, updateSearchQuery }: any) => (
   </I18n>
 );
 
-const SearchHits = ({ hits, locale }: any) =>
+type SearchHitsProps = {
+  hits?: {
+    slug: string;
+    title: string;
+  }[];
+};
+
+const SearchHits = ({ hits }: SearchHitsProps) =>
   hits && hits.length > 0 ? (
     <div className="dropdown-content">
       {hits
         .map((hit: any) => (
-          <Link
+          <LocaleLink
             key={hit.slug}
-            to={(locale ? "/" + locale : "") + "/learn/" + hit.slug}
+            to={"/learn/" + hit.slug}
             className="dropdown-item"
           >
             <div className="is-size-6 has-text-primary has-text-weight-semibold">
@@ -61,7 +68,7 @@ const SearchHits = ({ hits, locale }: any) =>
             <div className="result__snippet">
               <Snippet attribute="articleContent" hit={hit} tagName="u" />
             </div>
-          </Link>
+          </LocaleLink>
         ))
         .slice(0, SEARCH_RESULTS_LIMIT)}
     </div>

--- a/src/components/locale-link.tsx
+++ b/src/components/locale-link.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { Link, GatsbyLinkProps } from "gatsby";
+import { useCurrentLocale } from "../util/use-locale";
+
+export function LocaleLink<TState>(
+  props: GatsbyLinkProps<TState> & { ref?: any }
+): JSX.Element {
+  const locale = useCurrentLocale();
+
+  return <Link {...props} to={`/${locale}${props.to}`} />;
+}

--- a/src/components/locale-link.tsx
+++ b/src/components/locale-link.tsx
@@ -10,7 +10,7 @@ import { useCurrentLocale } from "../util/use-locale";
  * the path!
  */
 export function LocaleLink<TState>(
-  props: GatsbyLinkProps<TState> & { ref?: any }
+  props: GatsbyLinkProps<TState> & { ref?: never }
 ): JSX.Element {
   const locale = useCurrentLocale();
 

--- a/src/components/locale-link.tsx
+++ b/src/components/locale-link.tsx
@@ -2,6 +2,13 @@ import React from "react";
 import { Link, GatsbyLinkProps } from "gatsby";
 import { useCurrentLocale } from "../util/use-locale";
 
+/**
+ * Like Gatsby's <Link>, but it prefixes the passed-in `to` prop with
+ * the current locale.
+ *
+ * Note that this doesn't localize the actual *text* of the link--it only localizes
+ * the path!
+ */
 export function LocaleLink<TState>(
   props: GatsbyLinkProps<TState> & { ref?: any }
 ): JSX.Element {

--- a/src/components/read-more.tsx
+++ b/src/components/read-more.tsx
@@ -1,17 +1,16 @@
 import React from "react";
-import { Link } from "gatsby";
 import { Trans } from "@lingui/macro";
 
 import "../styles/read-more.scss";
-import { Locale } from "../pages/index.en";
+import { LocaleLink } from "./locale-link";
 
 type Props = {
   title: string;
   link: string;
-} & Locale;
+};
 
-const ReadMore = ({ title, link, locale }: Props) => (
-  <Link to={(locale ? "/" + locale : "") + link}>
+const ReadMore = ({ title, link }: Props) => (
+  <LocaleLink to={link}>
     <div className="level read-more section content">
       <div className="level-left">
         <div className="level-item">
@@ -32,7 +31,7 @@ const ReadMore = ({ title, link, locale }: Props) => (
         </div>
       </div>
     </div>
-  </Link>
+  </LocaleLink>
 );
 
 export default ReadMore;

--- a/src/pages/about/partners.en.tsx
+++ b/src/pages/about/partners.en.tsx
@@ -74,7 +74,6 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
       <ReadMore
         title={props.content.readMore.title}
         link={props.content.readMore.link}
-        locale={props.locale}
       />
     </div>
   </Layout>

--- a/src/pages/about/press.en.tsx
+++ b/src/pages/about/press.en.tsx
@@ -62,7 +62,6 @@ export const PressPageScaffolding = (props: ContentfulContent) => (
       <ReadMore
         title={props.content.readMore.title}
         link={props.content.readMore.link}
-        locale={props.locale}
       />
     </div>
   </Layout>

--- a/src/pages/about/team.en.tsx
+++ b/src/pages/about/team.en.tsx
@@ -155,7 +155,6 @@ export const TeamPageScaffolding = (props: ContentfulContent) => (
       <ReadMore
         title={props.content.readMore.title}
         link={props.content.readMore.link}
-        locale={props.locale}
       />
     </div>
   </Layout>

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StaticQuery, graphql, Link } from "gatsby";
+import { StaticQuery, graphql } from "gatsby";
 
 import "../styles/learn.scss";
 
@@ -10,6 +10,7 @@ import LearningSearchBar from "../components/learning-center/learning-searchbar"
 import CategoryMenu from "../components/learning-center/category-menu";
 import { Trans } from "@lingui/macro";
 import classnames from "classnames";
+import { LocaleLink } from "../components/locale-link";
 
 const widont = require("widont");
 
@@ -29,13 +30,12 @@ export type Category = {
 };
 
 export const ArticlePreviewCard = (props: any) => {
-  const localePrefix = "/" + props.locale;
-  const url = localePrefix + "/learn/" + props.articleData.slug;
+  const url = "/learn/" + props.articleData.slug;
   const categoryLabels = props.articleData.categories.map(
     (category: Category, i: number) => (
-      <Link
+      <LocaleLink
         key={i}
-        to={localePrefix + "/learn/category/" + category.slug}
+        to={"/learn/category/" + category.slug}
         className={classnames(
           "tag",
           "is-uppercase",
@@ -44,25 +44,25 @@ export const ArticlePreviewCard = (props: any) => {
         )}
       >
         {category.title}
-      </Link>
+      </LocaleLink>
     )
   );
   return (
     <div className="box article-preview">
       <h1 className="title is-size-3 has-text-primary is-spaced has-text-weight-semibold">
-        <Link to={url}>{widont(props.articleData.title)}</Link>
+        <LocaleLink to={url}>{widont(props.articleData.title)}</LocaleLink>
       </h1>
       <h6 className="has-text-grey-dark">
         {widont(props.articleData.previewText.previewText)}
       </h6>
       <br />
       <div>
-        <Link
+        <LocaleLink
           to={url}
           className="is-inline-block is-size-7 is-uppercase has-text-weight-semibold has-letters-spaced"
         >
           <Trans>Read More</Trans> →
-        </Link>
+        </LocaleLink>
         <div className="tags is-hidden-mobile is-inline-block is-uppercase is-pulled-right has-letters-spaced">
           {categoryLabels}
         </div>

--- a/src/pages/our-mission.en.tsx
+++ b/src/pages/our-mission.en.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { StaticQuery, graphql } from "gatsby";
-import { Link } from "gatsby";
 
 import "../styles/mission.scss";
 
@@ -9,6 +8,7 @@ import ReadMore from "../components/read-more";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { ContentfulContent } from "./index.en";
 import { Trans } from "@lingui/macro";
+import { LocaleLink } from "../components/locale-link";
 
 export function CollaborationBanner(props: {
   title: string;
@@ -23,12 +23,12 @@ export function CollaborationBanner(props: {
           </h1>
           <p className="subtitle has-text-weight-medium">{props.subtitle}</p>
           <div className="buttons is-centered">
-            <Link
+            <LocaleLink
               to="/contact-us"
               className="button is-medium is-primary is-outlined is-inverted is-uppercase"
             >
               <Trans>Contact Us</Trans>
-            </Link>
+            </LocaleLink>
             <a
               href="https://donorbox.org/donate-to-justfix-nyc"
               className="button is-medium is-primary is-outlined is-inverted is-uppercase"
@@ -113,7 +113,6 @@ export const MissionPageScaffolding = (props: ContentfulContent) => (
       <ReadMore
         title={props.content.readMore.title}
         link={props.content.readMore.link}
-        locale={props.locale}
       />
     </div>
   </Layout>


### PR DESCRIPTION
This factors out a `<LocaleLink>` component that automatically prefixes the passed-in URL with the current locale, as in WoW (see https://github.com/JustFixNYC/who-owns-what/pull/186).
