### PR TITLE
Remove locale as a passed-down prop from all components

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -145,7 +145,6 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
           `./src/components/learning-center/category-page-template.tsx`
         ),
         context: {
-          locale: locale,
           content: category,
           categoryButtons: allCategoryButtons,
           thankYouBanner: thankYouBanner,
@@ -182,7 +181,6 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
         `./src/components/learning-center/article-template.tsx`
       ),
       context: {
-        locale: locale,
         learningCenterTitle: learningCenterTitle,
         allToolsCta: allToolsCta,
         articleFooter: articleFooter,

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,11 +4,10 @@ import { Trans } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
 
 import "../styles/footer.scss";
-import { Locale } from "../pages/index.en";
 import Subscribe from "./subscribe";
 import { LocaleLink as Link } from "./locale-link";
 
-const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
+const Footer = withI18n()(({ i18n }: withI18nProps) => {
   return (
     <div className="footer has-background-info">
       <div className="columns has-text-centered-touch is-desktop">
@@ -109,7 +108,7 @@ const Footer = withI18n()(({ locale, i18n }: Locale & withI18nProps) => {
           <h4 className="title is-size-5 has-text-white">
             <Trans>Join our mailing list!</Trans>
           </h4>
-          <Subscribe locale={locale} />
+          <Subscribe />
           <div className="field">
             <SocialIcon
               url="http://twitter.com/justfixnyc"

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -7,7 +7,8 @@ import { StaticQuery, graphql } from "gatsby";
 
 import Header from "./header";
 import Footer from "./footer";
-import { Locale, StringLocales } from "../pages/index.en";
+import { StringLocales } from "../pages/index.en";
+import { useCurrentLocale } from "../util/use-locale";
 
 const favicon16 = require("../img/brand/favicon-16x16.png");
 const favicon32 = require("../img/brand/favicon-32x32.png");
@@ -38,7 +39,7 @@ type Props = {
   };
   children: React.ReactNode;
   isLandingPage?: boolean;
-} & Locale;
+};
 
 /** Component checks for custom metadata attributes, and then uses the default homepage values as a fallback */
 const LayoutScaffolding = ({
@@ -46,7 +47,6 @@ const LayoutScaffolding = ({
   children,
   isLandingPage,
   defaultContent,
-  locale,
 }: Props) => {
   var title, description, keywords, shareImageURL;
   if (defaultContent && defaultContent.metadata) {
@@ -65,6 +65,8 @@ const LayoutScaffolding = ({
         metadata.shareImage.file.url) ||
       defaultContent.metadata.shareImage.file.url;
   }
+
+  const locale = useCurrentLocale();
 
   return (
     <I18nProvider language={locale || "en"} catalogs={catalogs}>
@@ -110,12 +112,12 @@ const LayoutScaffolding = ({
       </Helmet>
       <Header isLandingPage={isLandingPage} />
       <div>{children}</div>
-      <Footer locale={locale} />
+      <Footer />
     </I18nProvider>
   );
 };
 
-const Layout = ({ metadata, children, isLandingPage, locale }: Props) => (
+const Layout = ({ metadata, children, isLandingPage }: Props) => (
   <StaticQuery
     query={graphql`
       query {
@@ -141,7 +143,6 @@ const Layout = ({ metadata, children, isLandingPage, locale }: Props) => (
         defaultContent={data.contentfulHomePage}
         children={children}
         isLandingPage={isLandingPage}
-        locale={locale}
       />
     )}
   />

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -7,8 +7,8 @@ import { StaticQuery, graphql } from "gatsby";
 
 import Header from "./header";
 import Footer from "./footer";
-import { StringLocales } from "../pages/index.en";
 import { useCurrentLocale } from "../util/use-locale";
+import localeConfig from "../util/locale-config.json";
 
 const favicon16 = require("../img/brand/favicon-16x16.png");
 const favicon32 = require("../img/brand/favicon-32x32.png");
@@ -18,6 +18,9 @@ const SITE_TITLE_SUFFIX = " | JustFix.nyc";
 const TWITTER_HANDLE = "@JustFixNYC";
 const SITE_MAIN_URL = "https://www.justfix.nyc";
 const FB_APP_ID = "247990609143668";
+
+// All our supported locales.
+type StringLocales = "es" | "en";
 
 type LocaleCatalogs = {
   [K in StringLocales]: any;
@@ -66,10 +69,10 @@ const LayoutScaffolding = ({
       defaultContent.metadata.shareImage.file.url;
   }
 
-  const locale = useCurrentLocale();
+  const locale = useCurrentLocale() || localeConfig.DEFAULT_LOCALE;
 
   return (
-    <I18nProvider language={locale || "en"} catalogs={catalogs}>
+    <I18nProvider language={locale} catalogs={catalogs}>
       <Helmet
         link={[
           {
@@ -87,7 +90,7 @@ const LayoutScaffolding = ({
           { rel: "shortcut icon", type: "image/png", href: `${favicon96}` },
         ]}
       >
-        <html lang="en" />
+        <html lang={locale} />
         <title>{title}</title>
         <meta name="description" content={description} />
         <meta name="keywords" content={keywords} />

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -6,7 +6,6 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 
 import "../../styles/learn.scss";
 import { AllToolsCta } from "./all-tools-cta";
-import { Locale } from "../../pages/index.en";
 import { Trans } from "@lingui/macro";
 import { LocaleLink } from "../locale-link";
 
@@ -18,7 +17,7 @@ type Props = {
     content: any;
     articleFooter: any;
     allToolsCta: any;
-  } & Locale;
+  };
 };
 
 type navMenuProps = {

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -135,7 +135,7 @@ const LearningArticle = (props: Props) => {
   );
 
   return (
-    <Layout metadata={content.metadata} locale={props.pageContext.locale}>
+    <Layout metadata={content.metadata}>
       <div className="article-page">
         <div className="columns is-desktop">
           <div className="column" />
@@ -209,10 +209,7 @@ const LearningArticle = (props: Props) => {
                     );
                   }
                 )}
-                <AllToolsCta
-                  content={props.pageContext.allToolsCta}
-                  locale={props.pageContext.locale}
-                />
+                <AllToolsCta content={props.pageContext.allToolsCta} />
                 <br />
               </div>
             </div>
@@ -221,10 +218,7 @@ const LearningArticle = (props: Props) => {
             <NavMenu styleClass="sticky is-hidden-touch" />
           </div>
         </div>
-        <LearningArticleFooter
-          content={props.pageContext.articleFooter}
-          locale={props.pageContext.locale}
-        />
+        <LearningArticleFooter content={props.pageContext.articleFooter} />
       </div>
     </Layout>
   );

--- a/src/components/learning-center/category-page-template.tsx
+++ b/src/components/learning-center/category-page-template.tsx
@@ -3,7 +3,6 @@ import Layout from "../layout";
 import { ArticlePreviewCard, sortArticlesByDate } from "../../pages/learn.en";
 import { ThankYouBanner } from "./thank-you-banner";
 import CategoryMenu from "./category-menu";
-import { Locale } from "../../pages/index.en";
 import { Trans } from "@lingui/macro";
 import { LocaleLink } from "../locale-link";
 
@@ -15,7 +14,7 @@ type Props = {
     thankYouBanner: any;
     categoryButtons: any;
     articlePreviews: any;
-  } & Locale;
+  };
 };
 
 const NoArticlesYet = () => (

--- a/src/components/learning-center/category-page-template.tsx
+++ b/src/components/learning-center/category-page-template.tsx
@@ -39,7 +39,6 @@ const LearningCategoryPage = (props: Props) => {
   return (
     <Layout
       metadata={{ title: content.title, description: content.description }}
-      locale={props.pageContext.locale}
     >
       <div className="category-page">
         <section className="hero is-small">
@@ -60,7 +59,6 @@ const LearningCategoryPage = (props: Props) => {
               <CategoryMenu
                 content={props.pageContext.categoryButtons}
                 selectedCategory={content.slug}
-                locale={props.pageContext.locale}
               />
             </div>
           </div>
@@ -70,20 +68,13 @@ const LearningCategoryPage = (props: Props) => {
             articlePreviews
               .sort(sortArticlesByDate)
               .map((article: any, i: number) => (
-                <ArticlePreviewCard
-                  articleData={article}
-                  key={i}
-                  locale={props.pageContext.locale}
-                />
+                <ArticlePreviewCard articleData={article} key={i} />
               ))
           ) : (
             <NoArticlesYet />
           )}
         </section>
-        <ThankYouBanner
-          content={props.pageContext.thankYouBanner}
-          locale={props.pageContext.locale}
-        />
+        <ThankYouBanner content={props.pageContext.thankYouBanner} />
       </div>
     </Layout>
   );

--- a/src/components/learning-center/learning-searchbar.tsx
+++ b/src/components/learning-center/learning-searchbar.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useState } from "react";
 import algoliasearch from "algoliasearch/lite";
 import {
   InstantSearch,
@@ -12,6 +12,7 @@ import { SearchBoxExposed } from "react-instantsearch-core";
 import { I18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
 import { LocaleLink } from "../locale-link";
+import { useCurrentLocale } from "../../util/use-locale";
 
 const appId = process.env.GATSBY_ALGOLIA_APP_ID;
 const searchKey = process.env.GATSBY_ALGOLIA_SEARCH_KEY;
@@ -88,58 +89,45 @@ const CustomSearchBox = connectSearchBox(SearchBox) as React.ComponentClass<
 >;
 const CustomHits = connectHits(SearchHits) as React.ComponentClass<Hits & any>;
 
-type Props = any;
-type State = { query: string };
+const LearningSearchBar = () => {
+  const [query, setQuery] = useState("");
+  const locale = useCurrentLocale();
 
-class LearningSearchBar extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = {
-      query: "",
-    };
-  }
+  return appId && searchKey ? (
+    <div className="search-bar">
+      <InstantSearch
+        searchClient={algoliasearch(appId, searchKey)}
+        indexName={
+          locale !== "en" ? `learning_center_${locale}` : "learning_center"
+        }
+        resultsState={[]}
+      >
+        <CustomSearchBox updateSearchQuery={(e: any) => setQuery(e)} />
 
-  render() {
-    return appId && searchKey ? (
-      <div className="search-bar">
-        <InstantSearch
-          searchClient={algoliasearch(appId, searchKey)}
-          indexName={
-            this.props.locale && this.props.locale !== "en"
-              ? `learning_center_${this.props.locale}`
-              : "learning_center"
-          }
-          resultsState={[]}
-        >
-          <CustomSearchBox
-            updateSearchQuery={(e: any) => this.setState({ query: e })}
-          />
-
-          {(this.state.query || "").length > 0 && (
-            <React.Fragment>
-              <Configure
-                attributesToSnippet={["articleContent"]}
-                analytics={enableAnalytics === "1" || false}
-              />
-              <CustomHits />
-            </React.Fragment>
-          )}
-        </InstantSearch>
-
-        {this.state.query && (
-          <div className="search-by is-pulled-right">
-            <img
-              width="100"
-              height="20"
-              src={require("../../img/brand/algolia.svg")}
+        {(query || "").length > 0 && (
+          <React.Fragment>
+            <Configure
+              attributesToSnippet={["articleContent"]}
+              analytics={enableAnalytics === "1" || false}
             />
-          </div>
+            <CustomHits />
+          </React.Fragment>
         )}
-      </div>
-    ) : (
-      <React.Fragment />
-    );
-  }
-}
+      </InstantSearch>
+
+      {query && (
+        <div className="search-by is-pulled-right">
+          <img
+            width="100"
+            height="20"
+            src={require("../../img/brand/algolia.svg")}
+          />
+        </div>
+      )}
+    </div>
+  ) : (
+    <React.Fragment />
+  );
+};
 
 export default LearningSearchBar;

--- a/src/components/learning-center/learning-searchbar.tsx
+++ b/src/components/learning-center/learning-searchbar.tsx
@@ -9,7 +9,6 @@ import {
   Hits,
 } from "react-instantsearch-dom";
 import { SearchBoxExposed } from "react-instantsearch-core";
-import { Locale } from "../../pages/index.en";
 import { I18n } from "@lingui/react";
 import { t, Trans } from "@lingui/macro";
 import { LocaleLink } from "../locale-link";
@@ -89,7 +88,7 @@ const CustomSearchBox = connectSearchBox(SearchBox) as React.ComponentClass<
 >;
 const CustomHits = connectHits(SearchHits) as React.ComponentClass<Hits & any>;
 
-type Props = any & Locale;
+type Props = any;
 type State = { query: string };
 
 class LearningSearchBar extends Component<Props, State> {
@@ -122,7 +121,7 @@ class LearningSearchBar extends Component<Props, State> {
                 attributesToSnippet={["articleContent"]}
                 analytics={enableAnalytics === "1" || false}
               />
-              <CustomHits locale={this.props.locale} />
+              <CustomHits />
             </React.Fragment>
           )}
         </InstantSearch>

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -53,7 +53,7 @@ class SubscribeWithoutI18n extends React.Component<
       method: "POST",
       mode: "cors",
       body: `email=${encodeURIComponent(
-        email,
+        email
       )}&language=${locale}&source=orgsite`,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -73,7 +73,7 @@ class SubscribeWithoutI18n extends React.Component<
         } else {
           this.setState({
             response: i18n._(
-              t`Oops! A network error occurred. Try again later.`,
+              t`Oops! A network error occurred. Try again later.`
             ),
           });
         }

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { Trans, t } from "@lingui/macro";
 import { withI18n, withI18nProps } from "@lingui/react";
-import { Locale } from "../pages/index.en";
 import classnames from "classnames";
 
 type FormLocation = "footer" | "page";
 
-type SubscribeProps = { location?: FormLocation } & Locale & withI18nProps;
+type SubscribeProps = { location?: FormLocation } & withI18nProps;
 
 type SubscribeState = {
   email: string;
@@ -54,7 +53,7 @@ class SubscribeWithoutI18n extends React.Component<
       method: "POST",
       mode: "cors",
       body: `email=${encodeURIComponent(
-        email
+        email,
       )}&language=${locale}&source=orgsite`,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
@@ -74,7 +73,7 @@ class SubscribeWithoutI18n extends React.Component<
         } else {
           this.setState({
             response: i18n._(
-              t`Oops! A network error occurred. Try again later.`
+              t`Oops! A network error occurred. Try again later.`,
             ),
           });
         }

--- a/src/pages/404.en.tsx
+++ b/src/pages/404.en.tsx
@@ -2,14 +2,10 @@ import React from "react";
 import { Trans } from "@lingui/macro";
 import Layout from "../components/layout";
 import { withI18n } from "@lingui/react";
-import { useCurrentLocale } from "../util/use-locale";
-import { StringLocales } from "./index.en";
 
 export const NotFoundPage = withI18n()(() => {
-  // TO DO: Fix this forced typing here:
-  const locale = useCurrentLocale() as StringLocales;
   return (
-    <Layout metadata={{ title: "Page Not Found" }} locale={locale}>
+    <Layout metadata={{ title: "Page Not Found" }}>
       <section className="hero is-large has-background-info">
         <div className="hero-body has-text-centered">
           <h1 className="title has-text-danger is-uppercase">

--- a/src/pages/about/partners.en.tsx
+++ b/src/pages/about/partners.en.tsx
@@ -9,7 +9,7 @@ import { ContentfulContent } from "../index.en";
 import { CollaborationBanner } from "../our-mission.en";
 
 export const PartnersPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} locale={props.locale}>
+  <Layout metadata={props.content.metadata} >
     <div id="partners" className="partners-page">
       <section className="hero is-small">
         <div className="hero-body has-text-centered is-horizontal-center">
@@ -139,7 +139,6 @@ const PartnersPage = () => (
     render={(data) => (
       <PartnersPageScaffolding
         content={data.contentfulPartnersPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/about/partners.en.tsx
+++ b/src/pages/about/partners.en.tsx
@@ -9,7 +9,7 @@ import { ContentfulContent } from "../index.en";
 import { CollaborationBanner } from "../our-mission.en";
 
 export const PartnersPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} >
+  <Layout metadata={props.content.metadata}>
     <div id="partners" className="partners-page">
       <section className="hero is-small">
         <div className="hero-body has-text-centered is-horizontal-center">
@@ -137,9 +137,7 @@ const PartnersPage = () => (
       }
     `}
     render={(data) => (
-      <PartnersPageScaffolding
-        content={data.contentfulPartnersPage}
-      />
+      <PartnersPageScaffolding content={data.contentfulPartnersPage} />
     )}
   />
 );

--- a/src/pages/about/partners.es.tsx
+++ b/src/pages/about/partners.es.tsx
@@ -10,9 +10,7 @@ const PartnersPage = () => (
       }
     `}
     render={(data) => (
-      <PartnersPageScaffolding
-        content={data.contentfulPartnersPage}
-      />
+      <PartnersPageScaffolding content={data.contentfulPartnersPage} />
     )}
   />
 );

--- a/src/pages/about/partners.es.tsx
+++ b/src/pages/about/partners.es.tsx
@@ -12,7 +12,6 @@ const PartnersPage = () => (
     render={(data) => (
       <PartnersPageScaffolding
         content={data.contentfulPartnersPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/about/press.en.tsx
+++ b/src/pages/about/press.en.tsx
@@ -10,7 +10,7 @@ import ReadMore from "../../components/read-more";
 import { ContentfulContent } from "../index.en";
 
 export const PressPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} locale={props.locale}>
+  <Layout metadata={props.content.metadata}>
     <div id="press" className="press-page">
       <section className="hero is-small">
         <div className="hero-body has-text-centered is-horizontal-center">
@@ -109,7 +109,7 @@ const PressPage = () => (
       }
     `}
     render={(data) => (
-      <PressPageScaffolding content={data.contentfulPressPage} locale="en" />
+      <PressPageScaffolding content={data.contentfulPressPage}  />
     )}
   />
 );

--- a/src/pages/about/press.en.tsx
+++ b/src/pages/about/press.en.tsx
@@ -109,7 +109,7 @@ const PressPage = () => (
       }
     `}
     render={(data) => (
-      <PressPageScaffolding content={data.contentfulPressPage}  />
+      <PressPageScaffolding content={data.contentfulPressPage} />
     )}
   />
 );

--- a/src/pages/about/press.es.tsx
+++ b/src/pages/about/press.es.tsx
@@ -10,7 +10,7 @@ const PressPage = () => (
       }
     `}
     render={(data) => (
-      <PressPageScaffolding content={data.contentfulPressPage} locale="es" />
+      <PressPageScaffolding content={data.contentfulPressPage} />
     )}
   />
 );

--- a/src/pages/about/team.en.tsx
+++ b/src/pages/about/team.en.tsx
@@ -11,7 +11,7 @@ import ReadMore from "../../components/read-more";
 import { ContentfulContent } from "../index.en";
 
 export const TeamPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} locale={props.locale}>
+  <Layout metadata={props.content.metadata} >
     <div id="team" className="team-page">
       <section className="hero is-small">
         <div className="hero-body has-text-centered is-horizontal-center">
@@ -225,7 +225,7 @@ const TeamPage = () => (
       }
     `}
     render={(data) => (
-      <TeamPageScaffolding content={data.contentfulTeamPage} locale="en" />
+      <TeamPageScaffolding content={data.contentfulTeamPage} />
     )}
   />
 );

--- a/src/pages/about/team.en.tsx
+++ b/src/pages/about/team.en.tsx
@@ -11,7 +11,7 @@ import ReadMore from "../../components/read-more";
 import { ContentfulContent } from "../index.en";
 
 export const TeamPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} >
+  <Layout metadata={props.content.metadata}>
     <div id="team" className="team-page">
       <section className="hero is-small">
         <div className="hero-body has-text-centered is-horizontal-center">
@@ -224,9 +224,7 @@ const TeamPage = () => (
         ...TeamPage
       }
     `}
-    render={(data) => (
-      <TeamPageScaffolding content={data.contentfulTeamPage} />
-    )}
+    render={(data) => <TeamPageScaffolding content={data.contentfulTeamPage} />}
   />
 );
 

--- a/src/pages/about/team.es.tsx
+++ b/src/pages/about/team.es.tsx
@@ -10,7 +10,7 @@ const TeamPage = () => (
       }
     `}
     render={(data) => (
-      <TeamPageScaffolding content={data.contentfulTeamPage} locale="es" />
+      <TeamPageScaffolding content={data.contentfulTeamPage} />
     )}
   />
 );

--- a/src/pages/about/team.es.tsx
+++ b/src/pages/about/team.es.tsx
@@ -9,9 +9,7 @@ const TeamPage = () => (
         ...TeamPage
       }
     `}
-    render={(data) => (
-      <TeamPageScaffolding content={data.contentfulTeamPage} />
-    )}
+    render={(data) => <TeamPageScaffolding content={data.contentfulTeamPage} />}
   />
 );
 

--- a/src/pages/changes.en.tsx
+++ b/src/pages/changes.en.tsx
@@ -79,7 +79,7 @@ export const ChangelogPageScaffolding: React.FC<{
   const { nodes } = content.allContentfulChangelogEntry;
 
   return (
-    <Layout locale={locale}>
+    <Layout>
       <div className="changes-page">
         <section className="hero is-small">
           <div className="hero-body has-text-centered is-horizontal-center content-wrapper tight">

--- a/src/pages/changes.en.tsx
+++ b/src/pages/changes.en.tsx
@@ -6,7 +6,6 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { EmbeddedAsset } from "../components/embedded-asset-node";
 
 import "../styles/changes.scss";
-import { StringLocales } from "./index.en";
 
 type ChangelogEntries = {
   allContentfulChangelogEntry: {
@@ -74,7 +73,7 @@ const ChangelogEntry: React.FC<{
 
 export const ChangelogPageScaffolding: React.FC<{
   content: ChangelogEntries;
-}> = ({ content, locale }) => {
+}> = ({ content }) => {
   const { nodes } = content.allContentfulChangelogEntry;
 
   return (

--- a/src/pages/changes.en.tsx
+++ b/src/pages/changes.en.tsx
@@ -74,7 +74,6 @@ const ChangelogEntry: React.FC<{
 
 export const ChangelogPageScaffolding: React.FC<{
   content: ChangelogEntries;
-  locale: StringLocales;
 }> = ({ content, locale }) => {
   const { nodes } = content.allContentfulChangelogEntry;
 
@@ -134,7 +133,7 @@ const EnglishChangelogPage: React.FC<{}> = () => (
         ...LocalizedChangelogEntries
       }
     `}
-    render={(data) => <ChangelogPageScaffolding content={data} locale="en" />}
+    render={(data) => <ChangelogPageScaffolding content={data} />}
   />
 );
 

--- a/src/pages/changes.es.tsx
+++ b/src/pages/changes.es.tsx
@@ -9,7 +9,7 @@ const SpanishChangelogPage: React.FC<{}> = () => (
         ...LocalizedChangelogEntries
       }
     `}
-    render={(data) => <ChangelogPageScaffolding content={data} locale="es" />}
+    render={(data) => <ChangelogPageScaffolding content={data} />}
   />
 );
 

--- a/src/pages/contact-us.en.tsx
+++ b/src/pages/contact-us.en.tsx
@@ -86,9 +86,7 @@ const ContactPage = () => (
       }
     `}
     render={(data) => (
-      <ContactPageScaffolding
-        content={data.contentfulContactPage}
-      />
+      <ContactPageScaffolding content={data.contentfulContactPage} />
     )}
   />
 );

--- a/src/pages/contact-us.en.tsx
+++ b/src/pages/contact-us.en.tsx
@@ -10,7 +10,7 @@ import { ContentfulContent } from "./index.en";
 import Subscribe from "../components/subscribe";
 
 export const ContactPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} locale={props.locale}>
+  <Layout metadata={props.content.metadata}>
     <div id="contact" className="contact-page">
       <section className="hero is-medium">
         <div className="hero-body has-text-centered is-horizontal-center content-wrapper">
@@ -41,7 +41,7 @@ export const ContactPageScaffolding = (props: ContentfulContent) => (
             <span className="subtitle has-text-grey-dark">
               {props.content.mailingListSubtitle}
             </span>
-            <Subscribe location="page" locale={props.locale} />
+            <Subscribe location="page" />
           </div>
         </div>
       </section>
@@ -88,7 +88,6 @@ const ContactPage = () => (
     render={(data) => (
       <ContactPageScaffolding
         content={data.contentfulContactPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/contact-us.es.tsx
+++ b/src/pages/contact-us.es.tsx
@@ -12,7 +12,6 @@ const ContactPage = () => (
     render={(data) => (
       <ContactPageScaffolding
         content={data.contentfulContactPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/contact-us.es.tsx
+++ b/src/pages/contact-us.es.tsx
@@ -10,9 +10,7 @@ const ContactPage = () => (
       }
     `}
     render={(data) => (
-      <ContactPageScaffolding
-        content={data.contentfulContactPage}
-      />
+      <ContactPageScaffolding content={data.contentfulContactPage} />
     )}
   />
 );

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -24,7 +24,7 @@ export type Locale = {
   locale: StringLocales;
 };
 
-export type ContentfulContent = Locale & {
+export type ContentfulContent = {
   content: any;
 };
 
@@ -46,7 +46,7 @@ const DDO = () => (
 );
 
 export const LandingPageScaffolding = (props: ContentfulContent) => (
-  <Layout isLandingPage={true} locale={props.locale}>
+  <Layout isLandingPage={true}>
     <div id="home" className="home-page">
       <BackgroundImage
         className="landing-image hero is-fullheight"
@@ -301,7 +301,7 @@ const LandingPage = () => (
       }
     `}
     render={(data) => (
-      <LandingPageScaffolding content={data.contentfulHomePage} locale="en" />
+      <LandingPageScaffolding content={data.contentfulHomePage} />
     )}
   />
 );

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -20,10 +20,6 @@ const PRODUCT_CTA_UTM_CODE = "?utm_source=orgsite&utm_medium=productcta";
 // All our supported locales.
 export type StringLocales = "es" | "en";
 
-export type Locale = {
-  locale: StringLocales;
-};
-
 export type ContentfulContent = {
   content: any;
 };

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -17,9 +17,6 @@ import { I18n } from "@lingui/react";
 const TEXTLOOP_ANIMATION_INTERVAL = 2750;
 const PRODUCT_CTA_UTM_CODE = "?utm_source=orgsite&utm_medium=productcta";
 
-// All our supported locales.
-export type StringLocales = "es" | "en";
-
 export type ContentfulContent = {
   content: any;
 };

--- a/src/pages/index.es.tsx
+++ b/src/pages/index.es.tsx
@@ -10,7 +10,7 @@ const LandingPage = () => (
       }
     `}
     render={(data) => (
-      <LandingPageScaffolding content={data.contentfulHomePage} locale="es" />
+      <LandingPageScaffolding content={data.contentfulHomePage} />
     )}
   />
 );

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -75,7 +75,7 @@ export const ArticlePreviewCard = (props: any) => {
 };
 
 export const LearningPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} locale={props.locale}>
+  <Layout metadata={props.content.metadata}>
     <div id="learning-center" className="learning-center-page">
       <section className="hero is-small">
         <div className="hero-body has-text-centered is-horizontal-center">
@@ -185,7 +185,6 @@ const LearningPage = () => (
     render={(data) => (
       <LearningPageScaffolding
         content={data.contentfulLearningCenterSearchPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -89,12 +89,9 @@ export const LearningPageScaffolding = (props: ContentfulContent) => (
             <h6 className="subtitle has-text-grey-dark is-italic">
               {widont(props.content.subtitle)}
             </h6>
-            <LearningSearchBar locale={props.locale} />
+            <LearningSearchBar />
             <br />
-            <CategoryMenu
-              content={props.content.categoryButtons}
-              locale={props.locale}
-            />
+            <CategoryMenu content={props.content.categoryButtons} />
           </div>
         </div>
       </section>
@@ -102,17 +99,10 @@ export const LearningPageScaffolding = (props: ContentfulContent) => (
         {props.content.articles
           .sort(sortArticlesByDate)
           .map((article: any, i: number) => (
-            <ArticlePreviewCard
-              articleData={article}
-              key={i}
-              locale={props.locale}
-            />
+            <ArticlePreviewCard articleData={article} key={i} />
           ))}
       </section>
-      <ThankYouBanner
-        content={props.content.thankYouText}
-        locale={props.locale}
-      />
+      <ThankYouBanner content={props.content.thankYouText} />
     </div>
   </Layout>
 );

--- a/src/pages/learn.es.tsx
+++ b/src/pages/learn.es.tsx
@@ -12,7 +12,6 @@ const LearningPage = () => (
     render={(data) => (
       <LearningPageScaffolding
         content={data.contentfulLearningCenterSearchPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/our-mission.en.tsx
+++ b/src/pages/our-mission.en.tsx
@@ -45,7 +45,7 @@ export function CollaborationBanner(props: {
 }
 
 export const MissionPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={props.content.metadata} locale={props.locale}>
+  <Layout metadata={props.content.metadata}>
     <div id="mission" className="mission-page">
       <section className="hero is-small">
         <div className="hero-body has-text-centered is-horizontal-center">
@@ -170,7 +170,6 @@ const MissionPage = () => (
     render={(data) => (
       <MissionPageScaffolding
         content={data.contentfulMissionPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/our-mission.en.tsx
+++ b/src/pages/our-mission.en.tsx
@@ -168,9 +168,7 @@ const MissionPage = () => (
       }
     `}
     render={(data) => (
-      <MissionPageScaffolding
-        content={data.contentfulMissionPage}
-      />
+      <MissionPageScaffolding content={data.contentfulMissionPage} />
     )}
   />
 );

--- a/src/pages/our-mission.es.tsx
+++ b/src/pages/our-mission.es.tsx
@@ -12,7 +12,6 @@ const MissionPage = () => (
     render={(data) => (
       <MissionPageScaffolding
         content={data.contentfulMissionPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/our-mission.es.tsx
+++ b/src/pages/our-mission.es.tsx
@@ -10,9 +10,7 @@ const MissionPage = () => (
       }
     `}
     render={(data) => (
-      <MissionPageScaffolding
-        content={data.contentfulMissionPage}
-      />
+      <MissionPageScaffolding content={data.contentfulMissionPage} />
     )}
   />
 );

--- a/src/pages/privacy-policy-norent.en.tsx
+++ b/src/pages/privacy-policy-norent.en.tsx
@@ -10,7 +10,6 @@ export const NorentPrivacyPolicyPageScaffolding = (
 ) => (
   <Layout
     metadata={{ title: "Privacy Policy for NoRent" }}
-    locale={props.locale}
   >
     <div
       id="privacy-policy"
@@ -47,7 +46,6 @@ const NorentPrivacyPolicyPage = () => (
     render={(data) => (
       <NorentPrivacyPolicyPageScaffolding
         content={data.contentfulGenericPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/privacy-policy-norent.en.tsx
+++ b/src/pages/privacy-policy-norent.en.tsx
@@ -8,9 +8,7 @@ import { ContentfulContent } from "./index.en";
 export const NorentPrivacyPolicyPageScaffolding = (
   props: ContentfulContent
 ) => (
-  <Layout
-    metadata={{ title: "Privacy Policy for NoRent" }}
-  >
+  <Layout metadata={{ title: "Privacy Policy for NoRent" }}>
     <div
       id="privacy-policy"
       className="privacy-policy-page content-wrapper tight section"

--- a/src/pages/privacy-policy-norent.es.tsx
+++ b/src/pages/privacy-policy-norent.es.tsx
@@ -12,7 +12,6 @@ const NorentPrivacyPolicyPage = () => (
     render={(data) => (
       <NorentPrivacyPolicyPageScaffolding
         content={data.contentfulGenericPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/privacy-policy.en.tsx
+++ b/src/pages/privacy-policy.en.tsx
@@ -6,7 +6,7 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { ContentfulContent } from "./index.en";
 
 export const PrivacyPolicyPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={{ title: "Privacy Policy" }} locale={props.locale}>
+  <Layout metadata={{ title: "Privacy Policy" }} >
     <div
       id="privacy-policy"
       className="privacy-policy-page content-wrapper tight section"
@@ -42,7 +42,6 @@ const PrivacyPolicyPage = () => (
     render={(data) => (
       <PrivacyPolicyPageScaffolding
         content={data.contentfulGenericPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/privacy-policy.en.tsx
+++ b/src/pages/privacy-policy.en.tsx
@@ -6,7 +6,7 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { ContentfulContent } from "./index.en";
 
 export const PrivacyPolicyPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={{ title: "Privacy Policy" }} >
+  <Layout metadata={{ title: "Privacy Policy" }}>
     <div
       id="privacy-policy"
       className="privacy-policy-page content-wrapper tight section"
@@ -40,9 +40,7 @@ const PrivacyPolicyPage = () => (
       }
     `}
     render={(data) => (
-      <PrivacyPolicyPageScaffolding
-        content={data.contentfulGenericPage}
-      />
+      <PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} />
     )}
   />
 );

--- a/src/pages/privacy-policy.es.tsx
+++ b/src/pages/privacy-policy.es.tsx
@@ -12,7 +12,6 @@ const PrivacyPolicyPage = () => (
     render={(data) => (
       <PrivacyPolicyPageScaffolding
         content={data.contentfulGenericPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/privacy-policy.es.tsx
+++ b/src/pages/privacy-policy.es.tsx
@@ -10,9 +10,7 @@ const PrivacyPolicyPage = () => (
       }
     `}
     render={(data) => (
-      <PrivacyPolicyPageScaffolding
-        content={data.contentfulGenericPage}
-      />
+      <PrivacyPolicyPageScaffolding content={data.contentfulGenericPage} />
     )}
   />
 );

--- a/src/pages/subscribed.en.tsx
+++ b/src/pages/subscribed.en.tsx
@@ -6,7 +6,7 @@ import Layout from "../components/layout";
 import { ContentfulContent } from "./index.en";
 
 export const SubscribedPageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={{ title: "Subscribed" }} locale={props.locale}>
+  <Layout metadata={{ title: "Subscribed" }}>
     <section className="hero is-small">
       <div className="hero-body has-text-centered is-horizontal-center">
         <div className="content content-wrapper tight">
@@ -61,7 +61,6 @@ const SubscribedPage = () => (
     render={(data) => (
       <SubscribedPageScaffolding
         content={data.contentfulSubscriptionConfirmationPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/subscribed.es.tsx
+++ b/src/pages/subscribed.es.tsx
@@ -12,7 +12,6 @@ const SubscribedPage = () => (
     render={(data) => (
       <SubscribedPageScaffolding
         content={data.contentfulSubscriptionConfirmationPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/terms-of-use-norent.en.tsx
+++ b/src/pages/terms-of-use-norent.en.tsx
@@ -6,7 +6,7 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { ContentfulContent } from "./index.en";
 
 export const NorentTermsOfUsePageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={{ title: "Terms of Use for NoRent" }} locale={props.locale}>
+  <Layout metadata={{ title: "Terms of Use for NoRent" }}>
     <div
       id="terms-of-use"
       className="terms-of-use-page content-wrapper tight section"
@@ -42,7 +42,6 @@ const NorentTermsOfUsePage = () => (
     render={(data) => (
       <NorentTermsOfUsePageScaffolding
         content={data.contentfulGenericPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/terms-of-use-norent.en.tsx
+++ b/src/pages/terms-of-use-norent.en.tsx
@@ -40,9 +40,7 @@ const NorentTermsOfUsePage = () => (
       }
     `}
     render={(data) => (
-      <NorentTermsOfUsePageScaffolding
-        content={data.contentfulGenericPage}
-      />
+      <NorentTermsOfUsePageScaffolding content={data.contentfulGenericPage} />
     )}
   />
 );

--- a/src/pages/terms-of-use-norent.es.tsx
+++ b/src/pages/terms-of-use-norent.es.tsx
@@ -10,9 +10,7 @@ const NorentTermsOfUsePage = () => (
       }
     `}
     render={(data) => (
-      <NorentTermsOfUsePageScaffolding
-        content={data.contentfulGenericPage}
-      />
+      <NorentTermsOfUsePageScaffolding content={data.contentfulGenericPage} />
     )}
   />
 );

--- a/src/pages/terms-of-use-norent.es.tsx
+++ b/src/pages/terms-of-use-norent.es.tsx
@@ -12,7 +12,6 @@ const NorentTermsOfUsePage = () => (
     render={(data) => (
       <NorentTermsOfUsePageScaffolding
         content={data.contentfulGenericPage}
-        locale="es"
       />
     )}
   />

--- a/src/pages/terms-of-use.en.tsx
+++ b/src/pages/terms-of-use.en.tsx
@@ -6,7 +6,7 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { ContentfulContent } from "./index.en";
 
 export const TermsOfUsePageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={{ title: "Terms of Use" }} locale={props.locale}>
+  <Layout metadata={{ title: "Terms of Use" }} >
     <div
       id="terms-of-use"
       className="terms-of-use-page content-wrapper tight section"
@@ -42,7 +42,6 @@ const TermsOfUsePage = () => (
     render={(data) => (
       <TermsOfUsePageScaffolding
         content={data.contentfulGenericPage}
-        locale="en"
       />
     )}
   />

--- a/src/pages/terms-of-use.en.tsx
+++ b/src/pages/terms-of-use.en.tsx
@@ -6,7 +6,7 @@ import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 import { ContentfulContent } from "./index.en";
 
 export const TermsOfUsePageScaffolding = (props: ContentfulContent) => (
-  <Layout metadata={{ title: "Terms of Use" }} >
+  <Layout metadata={{ title: "Terms of Use" }}>
     <div
       id="terms-of-use"
       className="terms-of-use-page content-wrapper tight section"
@@ -40,9 +40,7 @@ const TermsOfUsePage = () => (
       }
     `}
     render={(data) => (
-      <TermsOfUsePageScaffolding
-        content={data.contentfulGenericPage}
-      />
+      <TermsOfUsePageScaffolding content={data.contentfulGenericPage} />
     )}
   />
 );

--- a/src/pages/terms-of-use.es.tsx
+++ b/src/pages/terms-of-use.es.tsx
@@ -10,10 +10,7 @@ const TermsOfUsePage = () => (
       }
     `}
     render={(data) => (
-      <TermsOfUsePageScaffolding
-        content={data.contentfulGenericPage}
-        locale="es"
-      />
+      <TermsOfUsePageScaffolding content={data.contentfulGenericPage} />
     )}
   />
 );


### PR DESCRIPTION
Now that we have our fun little `useCurrentLocale()` hook, introduced in #130, we no longer need to pass down a "locale" prop through our component hierarchy to internationalize small components. This get's rid of all instances of that! 