### PR TITLE
Internationalize default page metadata

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -120,35 +120,64 @@ const LayoutScaffolding = ({
   );
 };
 
-const Layout = ({ metadata, children, isLandingPage }: Props) => (
-  <StaticQuery
-    query={graphql`
-      query {
-        contentfulHomePage {
-          metadata {
-            title
-            description
-            keywords {
-              keywords
-            }
-            shareImage {
-              file {
-                url
+type MetadataNodes = {
+  node_locale: string;
+  metadata: Props["metadata"];
+};
+
+function getDefaultContentForLocale(
+  locale: string,
+  nodes: MetadataNodes[]
+): Props["defaultContent"] {
+  for (let node of nodes) {
+    if (node.node_locale.startsWith(locale)) {
+      return { metadata: node.metadata };
+    }
+  }
+  throw new Error(
+    `Unable to find default content metadata for locale "${locale}"`
+  );
+}
+
+const Layout = ({ metadata, children, isLandingPage }: Props) => {
+  const locale = useCurrentLocale();
+
+  return (
+    <StaticQuery
+      query={graphql`
+        query {
+          allContentfulHomePage {
+            nodes {
+              node_locale
+              metadata {
+                title
+                description
+                keywords {
+                  keywords
+                }
+                shareImage {
+                  file {
+                    url
+                  }
+                }
               }
             }
           }
         }
-      }
-    `}
-    render={(data) => (
-      <LayoutScaffolding
-        metadata={metadata}
-        defaultContent={data.contentfulHomePage}
-        children={children}
-        isLandingPage={isLandingPage}
-      />
-    )}
-  />
-);
+      `}
+      render={(data) => (
+        <LayoutScaffolding
+          metadata={metadata}
+          defaultContent={getDefaultContentForLocale(
+            locale,
+            data.allContentfulHomePage.nodes
+          )}
+          children={children}
+          isLandingPage={isLandingPage}
+        />
+      )}
+    />
+  );
+};
 
 export default Layout;


### PR DESCRIPTION
This fixes #133 by retrieving the default content for _all_ locales and only using the one for the current page being rendered.

I'm guessing this might actually mean that JS-enabled browsers will also be downloading default content for all locales, too, but I've been unable to verify this via developer tools because I don't understand enough about how Gatsby is doing things.  However, even if this is the case, I don't think it should be too big a deal because the metadata per locale isn't that big, and we currently only have two locales.