### PR TITLE
Replaced COVID banner with component from monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^14.1.0",
     "@justfixnyc/geosearch-requester": "^0.0.6",
+    "@justfixnyc/react-common": "^0.0.1",
     "@lingui/react": "^2.8.3",
     "@reach/router": "1.3.4",
     "@types/classnames": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^14.1.0",
     "@justfixnyc/geosearch-requester": "^0.0.6",
-    "@justfixnyc/react-common": "^0.0.1",
+    "@justfixnyc/react-common": "^0.0.2",
     "@lingui/react": "^2.8.3",
     "@reach/router": "1.3.4",
     "@types/classnames": "^2.2.9",

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,6 +3,8 @@ import { Trans } from "@lingui/macro";
 
 import "../styles/header.scss";
 import { LocaleLink as Link } from "../components/locale-link";
+import { CovidMoratoriumBanner } from "@justfixnyc/react-common";
+import { useCurrentLocale } from "../util/use-locale";
 
 const isDemoSite = process.env.GATSBY_DEMO_SITE === "1";
 
@@ -12,6 +14,7 @@ const TENANT_PLATFORM_URL =
 
 const MoratoriumBanner = () => {
   const [isVisible, setVisibility] = useState(true);
+  const locale = useCurrentLocale();
 
   return (
     <section
@@ -24,24 +27,7 @@ const MoratoriumBanner = () => {
             onClick={() => setVisibility(false)}
           />
           <p>
-            <Trans>
-              <span className="has-text-weight-bold">COVID-19 Update: </span>
-              JustFix.nyc is operating, and has adapted our products to match
-              preliminary rules put in place during the COVID-19 crisis. We
-              recommend you take full precautions to stay safe during this
-              public health crisis. Thanks to tenant organizing during this
-              time, renters cannot be evicted for any reason. Visit{" "}
-              <a
-                href="https://www.righttocounselnyc.org/ny_eviction_moratorium_faq"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <span className="has-text-weight-bold">
-                  Right to Council’s Eviction Moratorium FAQs
-                </span>
-              </a>{" "}
-              to learn more.
-            </Trans>
+            <CovidMoratoriumBanner locale={locale} />
           </p>
         </div>
       </div>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,20 +13,16 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/header.tsx:15
-msgid "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
-msgstr "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
-
-#: src/components/footer.tsx:93
+#: src/components/footer.tsx:92
 msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 
-#: src/components/footer.tsx:102
+#: src/components/footer.tsx:101
 msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 
-#: src/components/footer.tsx:45
-#: src/components/header.tsx:70
+#: src/components/footer.tsx:44
+#: src/components/header.tsx:50
 msgid "About us"
 msgstr "About us"
 
@@ -34,7 +30,7 @@ msgstr "About us"
 msgid "All set! Thanks for subscribing!"
 msgstr "All set! Thanks for subscribing!"
 
-#: src/components/learning-center/category-page-template.tsx:30
+#: src/components/learning-center/category-page-template.tsx:29
 msgid "Back to Overview"
 msgstr "Back to Overview"
 
@@ -42,8 +38,8 @@ msgstr "Back to Overview"
 msgid "Back to top"
 msgstr "Back to top"
 
-#: src/components/footer.tsx:64
-#: src/components/header.tsx:104
+#: src/components/footer.tsx:63
+#: src/components/header.tsx:84
 msgid "Contact"
 msgstr "Contact"
 
@@ -51,11 +47,11 @@ msgstr "Contact"
 msgid "Contact Us"
 msgstr "Contact Us"
 
-#: src/components/header.tsx:54
+#: src/components/header.tsx:35
 msgid "DEMO SITE"
 msgstr "DEMO SITE"
 
-#: src/components/footer.tsx:69
+#: src/components/footer.tsx:68
 #: src/pages/our-mission.en.tsx:22
 msgid "Donate"
 msgstr "Donate"
@@ -70,30 +66,30 @@ msgstr "Email Address"
 msgid "Enter your address to learn more."
 msgstr "Enter your address to learn more."
 
-#: src/components/footer.tsx:59
-#: src/components/header.tsx:87
+#: src/components/footer.tsx:58
+#: src/components/header.tsx:67
 msgid "Jobs"
 msgstr "Jobs"
 
-#: src/components/footer.tsx:76
+#: src/components/footer.tsx:75
 msgid "Join our mailing list!"
 msgstr "Join our mailing list!"
 
-#: src/components/footer.tsx:28
-#: src/components/header.tsx:99
+#: src/components/footer.tsx:27
+#: src/components/header.tsx:79
 msgid "Learn"
 msgstr "Learn"
 
-#: src/components/footer.tsx:33
-#: src/components/header.tsx:75
+#: src/components/footer.tsx:32
+#: src/components/header.tsx:55
 msgid "Mission"
 msgstr "Mission"
 
-#: src/components/learning-center/learning-searchbar.tsx:32
+#: src/components/learning-center/learning-searchbar.tsx:33
 msgid "No articles match your search."
 msgstr "No articles match your search."
 
-#: src/pages/404.tsx:8
+#: src/pages/404.en.tsx:10
 msgid "Not found"
 msgstr "Not found"
 
@@ -106,8 +102,8 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/footer.tsx:54
-#: src/components/header.tsx:81
+#: src/components/footer.tsx:53
+#: src/components/header.tsx:61
 msgid "Partners"
 msgstr "Partners"
 
@@ -115,17 +111,17 @@ msgstr "Partners"
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/components/footer.tsx:38
-#: src/components/header.tsx:84
+#: src/components/footer.tsx:37
+#: src/components/header.tsx:64
 msgid "Press"
 msgstr "Press"
 
-#: src/components/footer.tsx:108
+#: src/components/footer.tsx:107
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
-#: src/components/footer.tsx:23
-#: src/components/header.tsx:94
+#: src/components/footer.tsx:22
+#: src/components/header.tsx:74
 msgid "Products"
 msgstr "Products"
 
@@ -138,16 +134,16 @@ msgstr "Read More"
 msgid "Search address"
 msgstr "Search address"
 
-#: src/components/learning-center/learning-searchbar.tsx:13
+#: src/components/learning-center/learning-searchbar.tsx:14
 msgid "Search articles..."
 msgstr "Search articles..."
 
-#: src/components/learning-center/article-template.tsx:59
+#: src/components/learning-center/article-template.tsx:58
 msgid "Sections"
 msgstr "Sections"
 
-#: src/components/header.tsx:110
-#: src/components/header.tsx:116
+#: src/components/header.tsx:90
+#: src/components/header.tsx:96
 msgid "Sign in"
 msgstr "Sign in"
 
@@ -155,16 +151,16 @@ msgstr "Sign in"
 msgid "Sign up"
 msgstr "Sign up"
 
-#: src/components/footer.tsx:49
-#: src/components/header.tsx:78
+#: src/components/footer.tsx:48
+#: src/components/header.tsx:58
 msgid "Team"
 msgstr "Team"
 
-#: src/components/footer.tsx:111
+#: src/components/footer.tsx:110
 msgid "Terms of use"
 msgstr "Terms of use"
 
-#: src/components/learning-center/article-template.tsx:103
+#: src/components/learning-center/article-template.tsx:99
 msgid "Updated"
 msgstr "Updated"
 
@@ -176,14 +172,14 @@ msgstr "Want to know more?"
 msgid "Want to take action?"
 msgstr "Want to take action?"
 
-#: src/components/footer.tsx:19
+#: src/components/footer.tsx:18
 msgid "What we do"
 msgstr "What we do"
 
-#: src/components/learning-center/article-template.tsx:99
+#: src/components/learning-center/article-template.tsx:95
 msgid "Written by"
 msgstr "Written by"
 
-#: src/pages/404.tsx:11
+#: src/pages/404.en.tsx:13
 msgid "You just found a page that doesn't exist... the sadness."
 msgstr "You just found a page that doesn't exist... the sadness."

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,20 +18,16 @@ msgstr ""
 "X-Crowdin-File: /master/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 19\n"
 
-#: src/components/header.tsx:15
-msgid "<0>COVID-19 Update: </0>JustFix.nyc is operating, and has adapted our products to match preliminary rules put in place during the COVID-19 crisis. We recommend you take full precautions to stay safe during this public health crisis. Thanks to tenant organizing during this time, renters cannot be evicted for any reason. Visit <1><2>Right to Council’s Eviction Moratorium FAQs</2></1> to learn more."
-msgstr "<0>Actualización COVID-19: </0>JustFix.nyc está operativo, y hemos adaptado nuestros productos a las normas establecidas durante la crisis de COVID-19. Todavía recomendamos que se tomen todas las precauciones posibles para mantenerse sanos durante esta crisis de salud pública. Gracias al poder de la organización de inquilinos, los inquilinos no pueden ser desalojados por ninguna razón. Visita las <1><2>Preguntas Más Frecuentes sobre la Moratoria de Desalojo del Right to Council</2></1> para obtener más información."
-
-#: src/components/footer.tsx:93
+#: src/components/footer.tsx:92
 msgid "<0>Disclaimer:</0> The information in JustFix.nyc does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "<0>Aviso:</0> La información en JustFix.nyc no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarle a dirigirle a servicios legales gratuitos si es necesario."
 
-#: src/components/footer.tsx:102
+#: src/components/footer.tsx:101
 msgid "<0>JustFix.nyc</0> is a registered 501(c)(3) nonprofit organization."
 msgstr "<0>JustFix.nyc</0> es una organización sin fines de lucro registrada."
 
-#: src/components/footer.tsx:45
-#: src/components/header.tsx:70
+#: src/components/footer.tsx:44
+#: src/components/header.tsx:50
 msgid "About us"
 msgstr "Sobre nosotros"
 
@@ -39,7 +35,7 @@ msgstr "Sobre nosotros"
 msgid "All set! Thanks for subscribing!"
 msgstr "¡Todo listo! ¡Gracias por suscribirte!"
 
-#: src/components/learning-center/category-page-template.tsx:30
+#: src/components/learning-center/category-page-template.tsx:29
 msgid "Back to Overview"
 msgstr "Volver a la Vista General"
 
@@ -47,8 +43,8 @@ msgstr "Volver a la Vista General"
 msgid "Back to top"
 msgstr "Vuelve a Inicio"
 
-#: src/components/footer.tsx:64
-#: src/components/header.tsx:104
+#: src/components/footer.tsx:63
+#: src/components/header.tsx:84
 msgid "Contact"
 msgstr "Contacto"
 
@@ -56,11 +52,11 @@ msgstr "Contacto"
 msgid "Contact Us"
 msgstr "Contáctanos"
 
-#: src/components/header.tsx:54
+#: src/components/header.tsx:35
 msgid "DEMO SITE"
 msgstr "SITIO DEMO"
 
-#: src/components/footer.tsx:69
+#: src/components/footer.tsx:68
 #: src/pages/our-mission.en.tsx:22
 msgid "Donate"
 msgstr "Dona"
@@ -75,30 +71,30 @@ msgstr "Correo electrónico"
 msgid "Enter your address to learn more."
 msgstr "Introduzca su dirección para empezar."
 
-#: src/components/footer.tsx:59
-#: src/components/header.tsx:87
+#: src/components/footer.tsx:58
+#: src/components/header.tsx:67
 msgid "Jobs"
 msgstr "Empleos"
 
-#: src/components/footer.tsx:76
+#: src/components/footer.tsx:75
 msgid "Join our mailing list!"
 msgstr "¡Únete a nuestra lista de correo!"
 
-#: src/components/footer.tsx:28
-#: src/components/header.tsx:99
+#: src/components/footer.tsx:27
+#: src/components/header.tsx:79
 msgid "Learn"
 msgstr "Aprende"
 
-#: src/components/footer.tsx:33
-#: src/components/header.tsx:75
+#: src/components/footer.tsx:32
+#: src/components/header.tsx:55
 msgid "Mission"
 msgstr "Misión"
 
-#: src/components/learning-center/learning-searchbar.tsx:32
+#: src/components/learning-center/learning-searchbar.tsx:33
 msgid "No articles match your search."
 msgstr "No hay resultados coincidan con su búsqueda."
 
-#: src/pages/404.tsx:8
+#: src/pages/404.en.tsx:10
 msgid "Not found"
 msgstr "No encontrado"
 
@@ -111,8 +107,8 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/footer.tsx:54
-#: src/components/header.tsx:81
+#: src/components/footer.tsx:53
+#: src/components/header.tsx:61
 msgid "Partners"
 msgstr "Aliados"
 
@@ -120,17 +116,17 @@ msgstr "Aliados"
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/components/footer.tsx:38
-#: src/components/header.tsx:84
+#: src/components/footer.tsx:37
+#: src/components/header.tsx:64
 msgid "Press"
 msgstr "Prensa"
 
-#: src/components/footer.tsx:108
+#: src/components/footer.tsx:107
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
-#: src/components/footer.tsx:23
-#: src/components/header.tsx:94
+#: src/components/footer.tsx:22
+#: src/components/header.tsx:74
 msgid "Products"
 msgstr "Herramientas"
 
@@ -143,16 +139,16 @@ msgstr "Lee más"
 msgid "Search address"
 msgstr "Busca dirección"
 
-#: src/components/learning-center/learning-searchbar.tsx:13
+#: src/components/learning-center/learning-searchbar.tsx:14
 msgid "Search articles..."
 msgstr "Busca artículos..."
 
-#: src/components/learning-center/article-template.tsx:59
+#: src/components/learning-center/article-template.tsx:58
 msgid "Sections"
 msgstr "Secciones"
 
-#: src/components/header.tsx:110
-#: src/components/header.tsx:116
+#: src/components/header.tsx:90
+#: src/components/header.tsx:96
 msgid "Sign in"
 msgstr "Inicia sesión"
 
@@ -160,16 +156,16 @@ msgstr "Inicia sesión"
 msgid "Sign up"
 msgstr "Únete"
 
-#: src/components/footer.tsx:49
-#: src/components/header.tsx:78
+#: src/components/footer.tsx:48
+#: src/components/header.tsx:58
 msgid "Team"
 msgstr "Equipo"
 
-#: src/components/footer.tsx:111
+#: src/components/footer.tsx:110
 msgid "Terms of use"
 msgstr "Condiciones de uso"
 
-#: src/components/learning-center/article-template.tsx:103
+#: src/components/learning-center/article-template.tsx:99
 msgid "Updated"
 msgstr "Actualizado"
 
@@ -181,15 +177,14 @@ msgstr "¿Quieres saber más?"
 msgid "Want to take action?"
 msgstr "¿Quieres tomar medidas?"
 
-#: src/components/footer.tsx:19
+#: src/components/footer.tsx:18
 msgid "What we do"
 msgstr "Lo que hacemos"
 
-#: src/components/learning-center/article-template.tsx:99
+#: src/components/learning-center/article-template.tsx:95
 msgid "Written by"
 msgstr "Escrita por"
 
-#: src/pages/404.tsx:11
+#: src/pages/404.en.tsx:13
 msgid "You just found a page that doesn't exist... the sadness."
 msgstr "Acabas de llegar a una ruta que no existe... es muy triste."
-

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -26,6 +26,7 @@
         a {
           color: inherit;
           text-decoration: underline;
+          font-weight: 700;
 
           &:hover {
             text-decoration: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,6 +2323,11 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
+"@justfixnyc/react-common@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.1.tgz#18c976322a97151e4e5f4bec14e8d202f049419d"
+  integrity sha512-UMx8JcMsARco0KwUFZ4/SO4XtNZkeVmMAT+bjWoax8fnFh+JplNl4l/mL0Gb2HfjdQsyAuPM24nuZ62vz4sYhQ==
+
 "@lingui/babel-plugin-extract-messages@2.8.3":
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-2.8.3.tgz#3fd6bcc97f7fec35b8b39731cd1d99596636a166"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
-"@justfixnyc/react-common@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.1.tgz#18c976322a97151e4e5f4bec14e8d202f049419d"
-  integrity sha512-UMx8JcMsARco0KwUFZ4/SO4XtNZkeVmMAT+bjWoax8fnFh+JplNl4l/mL0Gb2HfjdQsyAuPM24nuZ62vz4sYhQ==
+"@justfixnyc/react-common@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.2.tgz#180f47ccc31f21baac6813484b5de52f4953cb5c"
+  integrity sha512-YU/lEuEFXKdJtmtzQUG2EkUd9pS/inaZezCqsVFDZbLUC8M2atBTpMIfkFKsQyWf4dGMyUlXvzSqjF1r8DV2Tg==
 
 "@lingui/babel-plugin-extract-messages@2.8.3":
   version "2.8.3"


### PR DESCRIPTION
This PR makes use of the new `react-common` package out of our @justfixnyc monorepo on npm- we now pull the content for the COVID Eviction Moratorium banner from there.