### PR TITLE
Change all references of "Contact" to "Contact Us"

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -89,7 +89,7 @@ const Footer = withI18n()(({ i18n }: withI18nProps) => {
             to="/contact-us"
           >
             <p>
-              <Trans>Contact</Trans>
+              <Trans>Contact Us</Trans>
             </p>
           </Link>
           <a

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -146,7 +146,7 @@ const Header: React.FC<{
                 (burgerMenuIsOpen ? "black" : "white")
               }
             >
-              <Trans>Contact</Trans>
+              <Trans>Contact Us</Trans>
             </Link>
 
             {/* <Link to={this.props.locale === 'es' ? "/" : "/es"} className={"navbar-item has-text-" + (burgerMenuIsOpen ? "black" : "white")}>

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -40,9 +40,6 @@ msgstr "Back to top"
 
 #: src/components/footer.tsx:63
 #: src/components/header.tsx:84
-msgid "Contact"
-msgstr "Contact"
-
 #: src/pages/our-mission.en.tsx:19
 msgid "Contact Us"
 msgstr "Contact Us"

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -45,9 +45,6 @@ msgstr "Vuelve a Inicio"
 
 #: src/components/footer.tsx:63
 #: src/components/header.tsx:84
-msgid "Contact"
-msgstr "Contacto"
-
 #: src/pages/our-mission.en.tsx:19
 msgid "Contact Us"
 msgstr "Contáctanos"


### PR DESCRIPTION
This simple text change simplifies our translation and makes references to the contact page more uniform.