### PR TITLE
Replace previewText with metadata.description in Learning Center Article previews

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -80,9 +80,6 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
         subtitle {
           json
         }
-        previewText {
-          previewText
-        }
         author
         dateUpdated
         categories {
@@ -122,12 +119,12 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
       const {
         title,
         slug,
-        previewText,
+        metadata,
         categories,
         dateUpdated,
         ...rest
       } = article;
-      const subset = { title, slug, previewText, categories, dateUpdated };
+      const subset = { title, slug, metadata, categories, dateUpdated };
       return subset;
     }
   );

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -53,7 +53,7 @@ export const ArticlePreviewCard = (props: any) => {
         <LocaleLink to={url}>{widont(props.articleData.title)}</LocaleLink>
       </h1>
       <h6 className="has-text-grey-dark">
-        {widont(props.articleData.previewText.previewText)}
+        {widont(props.articleData.metadata.description)}
       </h6>
       <br />
       <div>
@@ -136,10 +136,10 @@ export const LearningPageFragment = graphql`
       articles {
         slug
         title
-        dateUpdated
-        previewText {
-          previewText
+        metadata {
+          description
         }
+        dateUpdated
         categories {
           title
           description


### PR DESCRIPTION
This PR coalesces our `previewText` and `metadata.description` content in Contentful in order to keep things more DRY from the perspective of the content creator. These two fields in our model had near duplicate content across our Learning Center article entries, so we are now just referencing `metadata.description` on our Learning Center article preview cards, and will plan to remove the `previewText` field entirely once this is deployed to production.