### PR TITLE
Remove links from other contributor section of Team page

### DIFF
--- a/src/pages/about/team.en.tsx
+++ b/src/pages/about/team.en.tsx
@@ -134,17 +134,7 @@ export const TeamPageScaffolding = (props: ContentfulContent) => (
                   className="has-text-weight-semibold has-text-grey-dark"
                   key={i}
                 >
-                  {contributor.link ? (
-                    <a
-                      href={contributor.link}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {contributor.name}
-                    </a>
-                  ) : (
-                    <>{contributor.name}</>
-                  )}
+                  {contributor.name}
                 </p>
               )
             )}
@@ -207,7 +197,6 @@ export const TeamPageFragment = graphql`
       otherContributorsTitle
       otherContributors {
         name
-        link
       }
       readMore {
         title


### PR DESCRIPTION
This PR removes hyperlinks from other contributor section of Team page, in our graphql schema and the front-end.
