### PR TITLE
Upgrade react-common package to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^14.1.0",
     "@justfixnyc/geosearch-requester": "^0.0.6",
-    "@justfixnyc/react-common": "^0.0.3",
+    "@justfixnyc/react-common": "^0.0.4",
     "@lingui/react": "^2.8.3",
     "@reach/router": "1.3.4",
     "@types/classnames": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^14.1.0",
     "@justfixnyc/geosearch-requester": "^0.0.6",
-    "@justfixnyc/react-common": "^0.0.4",
+    "@justfixnyc/react-common": "^0.0.5",
     "@lingui/react": "^2.8.3",
     "@reach/router": "1.3.4",
     "@types/classnames": "^2.2.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
-"@justfixnyc/react-common@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.3.tgz#c5ae7c7931487ab6256c525339d12bebddf1f482"
-  integrity sha512-HYRPG1NADdr7oQwZ/bl0Hluo0ckaKW2QWnsCYJhrKP4ubDLyNZGzDOTPqO6zUGZZ4mUG4iQmdpSbugNcGFsPjA==
+"@justfixnyc/react-common@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.4.tgz#1fee1c69441e7f028ec15599b0b520e7ed3667c8"
+  integrity sha512-PNBFy4OvSSuqr5eQiYbj9zouB5AUJNKifj+AbgkNHi4nndKsjDbcJrsE9hAzKQbkJ/vsI2wBw4o3EstU42Nrmw==
 
 "@lingui/babel-plugin-extract-messages@2.8.3":
   version "2.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
-"@justfixnyc/react-common@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.4.tgz#1fee1c69441e7f028ec15599b0b520e7ed3667c8"
-  integrity sha512-PNBFy4OvSSuqr5eQiYbj9zouB5AUJNKifj+AbgkNHi4nndKsjDbcJrsE9hAzKQbkJ/vsI2wBw4o3EstU42Nrmw==
+"@justfixnyc/react-common@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.5.tgz#d27ccdaf6f72a545ea70d441348525a2b1bbd17f"
+  integrity sha512-AHDvMh+yRwXiID/EE4qZlgVBvH6OcLskMeRMWAwwjq8SXeJCJ3NQMA8sAL8p3QyYXJk3sZuq/FUzSzlQViqIdg==
 
 "@lingui/babel-plugin-extract-messages@2.8.3":
   version "2.8.3"


### PR DESCRIPTION
This simple PR upgrades our react-common package so that we can update the content on our COVID moratorium banner component at the top of the landing page.

