### PR TITLE
Updated text on Moratorium Banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^14.1.0",
     "@justfixnyc/geosearch-requester": "^0.0.6",
-    "@justfixnyc/react-common": "^0.0.5",
+    "@justfixnyc/react-common": "^0.0.6",
     "@lingui/react": "^2.8.3",
     "@reach/router": "1.3.4",
     "@types/classnames": "^2.2.9",

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -20,7 +20,7 @@
   .hero.is-small.is-warning {
     padding: 0;
     .container {
-      max-width: 1200px;
+      max-width: 1300px;
       p {
         padding-right: 2rem;
         a {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2323,10 +2323,10 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
-"@justfixnyc/react-common@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.5.tgz#d27ccdaf6f72a545ea70d441348525a2b1bbd17f"
-  integrity sha512-AHDvMh+yRwXiID/EE4qZlgVBvH6OcLskMeRMWAwwjq8SXeJCJ3NQMA8sAL8p3QyYXJk3sZuq/FUzSzlQViqIdg==
+"@justfixnyc/react-common@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/react-common/-/react-common-0.0.6.tgz#f519de2bc2daa1e447690468f47a7bd57f4bff64"
+  integrity sha512-5R2wMkjwCtLeJlj/u3yB/ruDE2VzKN1npGcoTQCNwR679V99FAkHkhNDW9Y7lyUBWQfGyf4RhMxnsl7StA4d2g==
 
 "@lingui/babel-plugin-extract-messages@2.8.3":
   version "2.8.3"


### PR DESCRIPTION
This PR updates the `react-common` package to bring in new content for the moratorium banner component. It also tweaks the banner width to make the new text fit on two lines on desktop.