### PR TITLE
Localized link out to DDO

### DIFF
--- a/src/components/ddo-searchbar.test.tsx
+++ b/src/components/ddo-searchbar.test.tsx
@@ -18,14 +18,21 @@ describe("getDDOURL()", () => {
     ).toBe("http://boop/?address=blarg&borough=BRONX");
   });
 
+  it("includes locale path if providedincludes utm tags if provided", () => {
+    expect(
+      getDDOURL({ address: "blarg", borough: "BRONX" }, "http://boop/", "es")
+    ).toBe("http://boop/es/?address=blarg&borough=BRONX");
+  });
+
   it("includes utm tags if provided", () => {
     expect(
       getDDOURL(
         { address: "blarg", borough: "BRONX" },
         "http://boop/",
+        "en",
         "utm_source=boop"
       )
-    ).toBe("http://boop/?address=blarg&borough=BRONX&utm_source=boop");
+    ).toBe("http://boop/en/?address=blarg&borough=BRONX&utm_source=boop");
   });
 });
 

--- a/src/components/ddo-searchbar.tsx
+++ b/src/components/ddo-searchbar.tsx
@@ -31,6 +31,9 @@ export type DDOSearchBarProps = {
   /** The URL for DDO. */
   action?: string;
 
+  /** The specified locale for the DDO URL. */
+  locale?: string;
+
   /** Whether to forcibly disable address autocompletion functionality. */
   disableAutocomplete?: boolean;
 
@@ -44,7 +47,7 @@ export type DDOSearchBarProps = {
   customUtmTags?: string;
 };
 
-/** Return the DDO URL for the given address and/or borough. */
+/** Return the DDO URL for the given address and/or borough, and locale (optional). */
 export function getDDOURL(
   item: GeoAutocompleteItem,
   baseURL: string = DDO_URL,
@@ -100,14 +103,13 @@ export function DDOSearchBar(props: DDOSearchBarProps): JSX.Element {
   const [isNavigating, setIsNavigating] = useState(false);
   const GeoAutocompleteComponent =
     props.geoAutocompleteComponent || GeoAutocomplete;
-  const locale = useCurrentLocale();
   const gotoDDO = (item: GeoAutocompleteItem) => {
     setIsNavigating(true);
     window.location.assign(
       getDDOURL(
         item,
         props.action,
-        locale,
+        props.locale,
         props.customUtmTags || DDO_URL_UTM_TAGS
       )
     );

--- a/src/components/ddo-searchbar.tsx
+++ b/src/components/ddo-searchbar.tsx
@@ -5,7 +5,6 @@ import {
   GeoAutocompleteProps,
 } from "./geo-autocomplete";
 import classnames from "classnames";
-import { useCurrentLocale } from "../util/use-locale";
 
 /** The URL for Data-Driven Onboarding (DDO) on the JustFix Tenant Platform. */
 const DDO_URL =

--- a/src/components/ddo-searchbar.tsx
+++ b/src/components/ddo-searchbar.tsx
@@ -5,11 +5,12 @@ import {
   GeoAutocompleteProps,
 } from "./geo-autocomplete";
 import classnames from "classnames";
+import { useCurrentLocale } from "../util/use-locale";
 
 /** The URL for Data-Driven Onboarding (DDO) on the JustFix Tenant Platform. */
 const DDO_URL =
   (process.env.GATSBY_TENANT_PLATFORM_SITE_ORIGIN ||
-    "https://demo.justfix.nyc") + "/ddo";
+    "https://demo.justfix.nyc") + "/";
 
 /** The querystring variable used to communicate the address for DDO. */
 const DDO_ADDRESS_VAR = "address";
@@ -47,9 +48,13 @@ export type DDOSearchBarProps = {
 export function getDDOURL(
   item: GeoAutocompleteItem,
   baseURL: string = DDO_URL,
+  locale?: string,
   utmTags?: string
 ): string {
-  let url = `${baseURL}?${DDO_ADDRESS_VAR}=${encodeURIComponent(item.address)}`;
+  const localePath = locale ? locale + "/" : "";
+  let url = `${baseURL}${localePath}?${DDO_ADDRESS_VAR}=${encodeURIComponent(
+    item.address
+  )}`;
 
   if (item.borough) {
     url += `&${DDO_BOROUGH_VAR}=${encodeURIComponent(item.borough)}`;
@@ -95,10 +100,16 @@ export function DDOSearchBar(props: DDOSearchBarProps): JSX.Element {
   const [isNavigating, setIsNavigating] = useState(false);
   const GeoAutocompleteComponent =
     props.geoAutocompleteComponent || GeoAutocomplete;
+  const locale = useCurrentLocale();
   const gotoDDO = (item: GeoAutocompleteItem) => {
     setIsNavigating(true);
     window.location.assign(
-      getDDOURL(item, props.action, props.customUtmTags || DDO_URL_UTM_TAGS)
+      getDDOURL(
+        item,
+        props.action,
+        locale,
+        props.customUtmTags || DDO_URL_UTM_TAGS
+      )
     );
   };
 

--- a/src/components/learning-center/all-tools-cta.tsx
+++ b/src/components/learning-center/all-tools-cta.tsx
@@ -25,6 +25,7 @@ export const AllToolsCta = (props: ContentfulContent) => (
               <DDOSearchBar
                 hiddenFieldLabel={i18n._(t`Enter your address to learn more.`)}
                 submitLabel={i18n._(t`Search address`)}
+                locale={i18n.language}
                 customUtmTags="utm_source=orgsite&utm_medium=learning_center_cta"
                 withinCTA={true}
               />

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -32,6 +32,7 @@ const DDO = () => (
     <I18n>
       {({ i18n }) => (
         <DDOSearchBar
+          locale={i18n.language}
           hiddenFieldLabel={i18n._(t`Enter your address to learn more.`)}
           submitLabel={i18n._(t`Search address`)}
         />


### PR DESCRIPTION
This PR makes sure that the locale of the user on our org site matches the locale of where they get sent when they use a DDO Searchbar to search for their address— either on the landing page or within a Learning Center article. 