### PR TITLE
Add eviction free privacy policy and terms of use pages

### DIFF
--- a/src/pages/privacy-policy-eviction-free.en.tsx
+++ b/src/pages/privacy-policy-eviction-free.en.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+
+import Layout from "../components/layout";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { ContentfulContent } from "./index.en";
+
+export const EvictionFreePrivacyPolicyPageScaffolding = (
+  props: ContentfulContent
+) => (
+  <Layout metadata={{ title: props.content.pageTitle }}>
+    <div
+      id="privacy-policy"
+      className="privacy-policy-page content-wrapper tight section"
+    >
+      <div className="content">
+        {documentToReactComponents(props.content.pageContents.json)}
+      </div>
+    </div>
+  </Layout>
+);
+
+export const EvictionFreePrivacyPolicyPageFragment = graphql`
+  fragment EvictionFreePrivacyPolicyPage on Query {
+    contentfulGenericPage(
+      title: { eq: "Eviction Free NY Privacy Policy" }
+      node_locale: { eq: $locale }
+    ) {
+      title
+      pageTitle
+      pageContents {
+        json
+      }
+    }
+  }
+`;
+
+const EvictionFreePrivacyPolicyPage = () => (
+  <StaticQuery
+    query={graphql`
+      query($locale: String! = "en-US") {
+        ...EvictionFreePrivacyPolicyPage
+      }
+    `}
+    render={(data) => (
+      <EvictionFreePrivacyPolicyPageScaffolding
+        content={data.contentfulGenericPage}
+      />
+    )}
+  />
+);
+
+export default EvictionFreePrivacyPolicyPage;

--- a/src/pages/privacy-policy-eviction-free.es.tsx
+++ b/src/pages/privacy-policy-eviction-free.es.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+import { EvictionFreePrivacyPolicyPageScaffolding } from "./privacy-policy-eviction-free.en";
+
+const EvictionFreePrivacyPolicyPage = () => (
+  <StaticQuery
+    query={graphql`
+      query($locale: String! = "es") {
+        ...EvictionFreePrivacyPolicyPage
+      }
+    `}
+    render={(data) => (
+      <EvictionFreePrivacyPolicyPageScaffolding
+        content={data.contentfulGenericPage}
+      />
+    )}
+  />
+);
+
+export default EvictionFreePrivacyPolicyPage;

--- a/src/pages/terms-of-use-eviction-free.en.tsx
+++ b/src/pages/terms-of-use-eviction-free.en.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+
+import Layout from "../components/layout";
+import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import { ContentfulContent } from "./index.en";
+
+export const EvictionFreeTermsOfUsePageScaffolding = (
+  props: ContentfulContent
+) => (
+  <Layout metadata={{ title: props.content.pageTitle }}>
+    <div
+      id="terms-of-use"
+      className="terms-of-use-page content-wrapper tight section"
+    >
+      <div className="content">
+        {documentToReactComponents(props.content.pageContents.json)}
+      </div>
+    </div>
+  </Layout>
+);
+
+export const EvictionFreeTermsOfUsePageFragment = graphql`
+  fragment EvictionFreeTermsOfUsePage on Query {
+    contentfulGenericPage(
+      title: { eq: "Eviction Free NY Terms of Use" }
+      node_locale: { eq: $locale }
+    ) {
+      title
+      pageTitle
+      pageContents {
+        json
+      }
+    }
+  }
+`;
+
+const EvictionFreeTermsOfUsePage = () => (
+  <StaticQuery
+    query={graphql`
+      query($locale: String! = "en-US") {
+        ...EvictionFreeTermsOfUsePage
+      }
+    `}
+    render={(data) => (
+      <EvictionFreeTermsOfUsePageScaffolding
+        content={data.contentfulGenericPage}
+      />
+    )}
+  />
+);
+
+export default EvictionFreeTermsOfUsePage;

--- a/src/pages/terms-of-use-eviction-free.es.tsx
+++ b/src/pages/terms-of-use-eviction-free.es.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+import { EvictionFreeTermsOfUsePageScaffolding } from "./terms-of-use-eviction-free.en";
+
+const EvictionFreeTermsOfUsePage = () => (
+  <StaticQuery
+    query={graphql`
+      query($locale: String! = "es") {
+        ...EvictionFreeTermsOfUsePage
+      }
+    `}
+    render={(data) => (
+      <EvictionFreeTermsOfUsePageScaffolding
+        content={data.contentfulGenericPage}
+      />
+    )}
+  />
+);
+
+export default EvictionFreeTermsOfUsePage;


### PR DESCRIPTION
This PR adds in placeholder privacy policy and terms of use pages to link to from the new Eviction Free NY tool we are building. The new pages will be accessible at the routes `/terms-of-use-eviction-free` and `/privacy-policy-eviction-free`.