### PR TITLE
Spell out full language name in header toggle

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,6 +9,16 @@ import localeConfig from "../util/locale-config.json";
 
 const isDemoSite = process.env.GATSBY_DEMO_SITE === "1";
 
+type LocaleChoice = "en" | "es";
+
+/**
+ * Names of languages in the language itself.
+ */
+const LANGUAGE_NAMES: { [k in LocaleChoice]: string } = {
+  en: "English",
+  es: "Español",
+};
+
 const MoratoriumBanner = () => {
   const [isVisible, setVisibility] = useState(true);
   const locale = useCurrentLocale();
@@ -154,7 +164,7 @@ const Header: React.FC<{
                   (burgerMenuIsOpen ? "black" : "white")
                 }
               >
-                {locale.toUpperCase()}
+                {LANGUAGE_NAMES[locale]}
               </a>
 
               <div className="navbar-dropdown is-right">
@@ -162,7 +172,7 @@ const Header: React.FC<{
                   (otherLocale) => otherLocale !== locale
                 ).map((otherLocale) => (
                   <LocaleToggle to={otherLocale} className="navbar-item">
-                    {otherLocale.toUpperCase()}
+                    {LANGUAGE_NAMES[otherLocale]}
                   </LocaleToggle>
                 ))}
               </div>


### PR DESCRIPTION
This PR changes our labels for supported languages from the 2-character abbreviations (EN and ES) to the full language names (English and Español), following a similar PR on tenants2: https://github.com/JustFixNYC/tenants2/pull/1931.
