### PR TITLE
Fix Annual Report button width on Mission page

### DIFF
--- a/src/styles/mission.scss
+++ b/src/styles/mission.scss
@@ -21,6 +21,7 @@
 
         .button {
           margin: 0.75rem;
+          width: 175px;
         }
       }
 


### PR DESCRIPTION
Now that we have 4 annual reports on the Mission page, this PR defines a new styling prop to put our annual report buttons in a 2 x 2 grid.