### PR TITLE
Fix homepage overflow issue caused by section divider

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -41,6 +41,17 @@ const DDO = () => (
   </>
 );
 
+const ResponsiveSectionDivider = () => (
+  <>
+    <section className="columns is-centered is-hidden-mobile">
+      <div className="column is-four-fifths">
+        <div className="is-divider" />
+      </div>
+    </section>
+    <div className="is-divider is-hidden-tablet" />
+  </>
+);
+
 export const LandingPageScaffolding = (props: ContentfulContent) => (
   <Layout isLandingPage={true}>
     <div id="home" className="home-page">
@@ -207,11 +218,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
         </div>
       </section>
 
-      <section className="columns is-centered">
-        <div className="column is-four-fifths">
-          <div className="is-divider" />
-        </div>
-      </section>
+      <ResponsiveSectionDivider />
 
       <section id="as-seen-in">
         <div className="content-wrapper">


### PR DESCRIPTION
This PR fixes a bug where the content of the homepage extended beyond the `<body>` element on mobile, creating an ugly right margin. Turns out it was an issue with a section divider on the homepage. This refactoring addresses the issue by creating a new component that renders this section divider differently between desktop and mobile.