### PR TITLE
Add first set of deprecated LC article redirects

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -200,8 +200,12 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
 
 const deprecatedLearningCenterArticles = [
   {
-    slug: "how-to-break-a-lease",
+    slug: "how-to-break-a-leasey",
     redirectCategory: "laws",
+  },
+  {
+    slug: "public-eviction-records",
+    redirectCategory: "eviction",
   },
 ];
 
@@ -239,13 +243,16 @@ exports.createPages = async function ({ actions, graphql }) {
   );
   // Create redirects for old Learning Center articles that have been removed:
   deprecatedLearningCenterArticles.map(({ slug, redirectCategory }) =>
-    localeConfig.ACCEPTED_LOCALES.map((locale) =>
+    localeConfig.ACCEPTED_LOCALES.map((locale) => {
+      console.log(
+        `from /${locale}/learn/${slug} to /${locale}/learn/category/${redirectCategory}`
+      );
       createRedirect({
         fromPath: `/${locale}/learn/${slug}`,
         toPath: `/${locale}/learn/category/${redirectCategory}`,
         isPermanent: true,
-      })
-    )
+      });
+    })
   );
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -200,11 +200,39 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
 
 const deprecatedLearningCenterArticles = [
   {
-    slug: "how-to-break-a-leasey",
+    slug: "how-to-break-a-lease",
     redirectCategory: "laws",
   },
   {
     slug: "public-eviction-records",
+    redirectCategory: "eviction",
+  },
+  {
+    slug: "housing-discrimination-examples",
+    redirectCategory: "discrimination",
+  },
+  {
+    slug: "fair-housing-act",
+    redirectCategory: "laws",
+  },
+  {
+    slug: "eviction-notice-what-to-do",
+    redirectCategory: "eviction",
+  },
+  {
+    slug: "ny-eviction-moratorium-faq",
+    redirectCategory: "eviction",
+  },
+  {
+    slug: "nyc-housing-during-coronavirus",
+    redirectCategory: "laws",
+  },
+  {
+    slug: "homeless-during-coronavirus-nyc",
+    redirectCategory: "discrimination",
+  },
+  {
+    slug: "rent-freeze-faq",
     redirectCategory: "eviction",
   },
 ];

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -271,16 +271,13 @@ exports.createPages = async function ({ actions, graphql }) {
   );
   // Create redirects for old Learning Center articles that have been removed:
   deprecatedLearningCenterArticles.map(({ slug, redirectCategory }) =>
-    localeConfig.ACCEPTED_LOCALES.map((locale) => {
-      console.log(
-        `from /${locale}/learn/${slug} to /${locale}/learn/category/${redirectCategory}`
-      );
+    localeConfig.ACCEPTED_LOCALES.map((locale) =>
       createRedirect({
         fromPath: `/${locale}/learn/${slug}`,
         toPath: `/${locale}/learn/category/${redirectCategory}`,
         isPermanent: true,
-      });
-    })
+      })
+    )
   );
 };
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -198,6 +198,13 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
   });
 };
 
+const deprecatedLearningCenterArticles = [
+  {
+    slug: "how-to-break-a-lease",
+    redirectCategory: "laws",
+  },
+];
+
 exports.createPages = async function ({ actions, graphql }) {
   generateLearningPages({ actions, graphql }, "en"); // English pages
   generateLearningPages({ actions, graphql }, "es"); // Spanish pages
@@ -226,6 +233,16 @@ exports.createPages = async function ({ actions, graphql }) {
       createRedirect({
         fromPath: `/${locale}/about/${path}`,
         toPath: `/${locale}/${path}`,
+        isPermanent: true,
+      })
+    )
+  );
+  // Create redirects for old Learning Center articles that have been removed:
+  deprecatedLearningCenterArticles.map(({ slug, redirectCategory }) =>
+    localeConfig.ACCEPTED_LOCALES.map((locale) =>
+      createRedirect({
+        fromPath: `/${locale}/learn/${slug}`,
+        toPath: `/${locale}/learn/category/${redirectCategory}`,
         isPermanent: true,
       })
     )


### PR DESCRIPTION
This PR adds various permanent redirects for URLS to old Learning Center articles that we want to unpublish.