### PR TITLE
Add optional cover photo to top of article pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -78,6 +78,15 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
         slug
         englishOnly
         title
+        coverPhoto {
+          fluid {
+            base64
+            aspectRatio
+            src
+            srcSet
+            sizes
+          }
+        }
         subtitle {
           json
         }

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -9,6 +9,7 @@ import { AllToolsCta } from "./all-tools-cta";
 import { Trans } from "@lingui/macro";
 import { LocaleLink } from "../locale-link";
 import { useCurrentLocale } from "../../util/use-locale";
+import Img from "gatsby-image/withIEPolyfill";
 
 const widont = require("widont");
 
@@ -173,6 +174,14 @@ const LearningArticle = (props: Props) => {
                   <h1 className="title is-size-2 is-size-3-mobile has-text-grey-dark has-text-weight-semibold is-spaced">
                     {widont(content.title)}
                   </h1>
+                  {content.coverPhoto && (
+                    <div className="container">
+                      <figure className="image is-horizontal-center">
+                        <Img fluid={content.coverPhoto.fluid} alt="" />
+                      </figure>
+                      <br />
+                    </div>
+                  )}
                   <p className="subtitle is-size-6 has-text-grey-dark">
                     <span className="is-size-6">
                       <Trans>Written by</Trans> {content.author}


### PR DESCRIPTION
This PR adds the ability to include a cover photo for any learning center article, coinciding with a chance to the Contentful schema.