### PR TITLE
Format urls for share images when they start with forward slashes

### DIFF
--- a/src/components/layout.test.tsx
+++ b/src/components/layout.test.tsx
@@ -1,0 +1,22 @@
+import { formatImageUrlForSEO } from "./layout";
+
+describe("formatImageUrlForSEO()", () => {
+  it("doesn't format regualr urls", () => {
+    expect(formatImageUrlForSEO("www.boop.com")).toBe("www.boop.com");
+  });
+  it("encodes special characters inside urls", () => {
+    expect(formatImageUrlForSEO("www.boop.com/HELLO JONES")).toBe(
+      "www.boop.com/HELLO%20JONES"
+    );
+  });
+  it("reformats urls that start with two forward slashes", () => {
+    expect(formatImageUrlForSEO("//boop.assets.com/image.png")).toBe(
+      "https://boop.assets.com/image.png"
+    );
+  });
+  it("reformats and encodes urls at the same time ", () => {
+    expect(formatImageUrlForSEO("//boop.assets.com/100% fun.png")).toBe(
+      "https://boop.assets.com/100%25%20fun.png"
+    );
+  });
+});

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -31,6 +31,9 @@ const catalogs: LocaleCatalogs = {
   es: catalogEs,
 };
 
+export const formatImageUrlForSEO = (url: string) =>
+  url.startsWith("//") ? encodeURI(`https:${url}`) : encodeURI(url);
+
 // import './layout.css'
 
 type Props = {
@@ -51,7 +54,7 @@ const LayoutScaffolding = ({
   isLandingPage,
   defaultContent,
 }: Props) => {
-  var title, description, keywords, shareImageURL;
+  var title, description, keywords, imageUrl, shareImageURL;
   if (defaultContent && defaultContent.metadata) {
     title =
       (metadata && metadata.title + SITE_TITLE_SUFFIX) ||
@@ -61,12 +64,13 @@ const LayoutScaffolding = ({
     keywords =
       (metadata && metadata.keywords && metadata.keywords.keywords) ||
       defaultContent.metadata.keywords.keywords;
-    shareImageURL =
+    imageUrl =
       (metadata &&
         metadata.shareImage &&
         metadata.shareImage.file &&
         metadata.shareImage.file.url) ||
       defaultContent.metadata.shareImage.file.url;
+    shareImageURL = formatImageUrlForSEO(imageUrl);
   }
 
   const locale = useCurrentLocale() || localeConfig.DEFAULT_LOCALE;
@@ -101,7 +105,7 @@ const LayoutScaffolding = ({
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:url" content={SITE_MAIN_URL} />
-        <meta property="og:image" content={encodeURI(shareImageURL)} />
+        <meta property="og:image" content={shareImageURL} />
         <meta property="og:type" content="website" />
 
         <meta name="twitter:card" content="summary_large_image" />
@@ -110,7 +114,7 @@ const LayoutScaffolding = ({
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />
         <meta name="twitter:url" content={SITE_MAIN_URL} />
-        <meta name="twitter:image" content={encodeURI(shareImageURL)} />
+        <meta name="twitter:image" content={shareImageURL} />
         <meta name="twitter:image:alt" content={title} />
       </Helmet>
       <Header isLandingPage={isLandingPage} />


### PR DESCRIPTION
So, contentful provides raw URLs for the images it hosts using a special url structure that looks like `//images.ctfassets.net/...`. While gatsby is able to interpret that when sourcing images displayed on a page of the site, this url structure seems to create some confusion for browsers when this url type is placed as the `og:image` metatag value for the social media share image.

This PR makes sure that when we are setting an image-based metatag, we make sure to append `https:` to the front of these weird urls so they are universally recognized.  