### PR TITLE
Move article cover photos above title

### DIFF
--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -163,25 +163,23 @@ const LearningArticle = (props: Props) => {
                   </ul>
                 </nav>
                 <div className="container content-wrapper">
-                  {locale === "es" && content.englishOnly && (
-                    <>
-                      <p className="has-text-danger is-italic">
-                        Solo en inglés
-                      </p>
-                      <br />
-                    </>
-                  )}
-                  <h1 className="title is-size-2 is-size-3-mobile has-text-grey-dark has-text-weight-semibold is-spaced">
-                    {widont(content.title)}
-                  </h1>
                   {content.coverPhoto && (
                     <div className="container">
                       <figure className="image is-horizontal-center">
-                        <Img fluid={content.coverPhoto.fluid} alt="" />
+                        <Img
+                          fluid={content.coverPhoto.fluid}
+                          alt={content.title}
+                        />
                       </figure>
                       <br />
                     </div>
                   )}
+                  {locale === "es" && content.englishOnly && (
+                    <p className="has-text-danger is-italic">Solo en inglés</p>
+                  )}
+                  <h1 className="title is-size-2 is-size-3-mobile has-text-grey-dark has-text-weight-semibold is-spaced">
+                    {widont(content.title)}
+                  </h1>
                   <p className="subtitle is-size-6 has-text-grey-dark">
                     <span className="is-size-6">
                       <Trans>Written by</Trans> {content.author}


### PR DESCRIPTION
Simple html content change that switches the order of elements on our learning center article pages.