### PR TITLE
Allow embedding of photo assets in Learning Center articles

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/react-motion": "^0.0.29",
     "@types/react-scroll": "^1.5.4",
     "algoliasearch": "^3.35.1",
-    "bulma": "^0.8.0",
+    "bulma": "^0.9.0",
     "bulma-divider": "^0.2.0",
     "classnames": "^2.2.6",
     "dotenv": "^6.0.0",

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -10,6 +10,8 @@ import { Trans } from "@lingui/macro";
 import { LocaleLink } from "../locale-link";
 import { useCurrentLocale } from "../../util/use-locale";
 import Img from "gatsby-image/withIEPolyfill";
+import { EmbeddedAsset } from "../embedded-asset-node";
+import { BLOCKS } from "@contentful/rich-text-types";
 
 const widont = require("widont");
 
@@ -31,6 +33,7 @@ function makeSectionID(index: number): string {
 }
 
 function renderSection(articleSection: any, i: number): JSX.Element {
+  const locale = useCurrentLocale();
   return (
     <div key={i} id={makeSectionID(i)} className="article-section">
       {articleSection.__typename === "ContentfulLearningArticleCtaBlock" ? (
@@ -82,7 +85,15 @@ function renderSection(articleSection: any, i: number): JSX.Element {
             {widont(articleSection.title)}
           </h1>
           <span className="has-text-grey-dark">
-            {documentToReactComponents(articleSection.content.json)}
+            {documentToReactComponents(articleSection.content.json, {
+              renderNode: {
+                [BLOCKS.EMBEDDED_ASSET]: (eaNode) => (
+                  <p className="mt-5">
+                    <EmbeddedAsset node={eaNode} locale={locale} />
+                  </p>
+                ),
+              },
+            })}
           </span>
         </div>
       )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,10 +4396,10 @@ bulma-divider@^0.2.0:
   resolved "https://registry.yarnpkg.com/bulma-divider/-/bulma-divider-0.2.0.tgz#a9b4d9fe8b270c7cb7573023c575062bc62616f3"
   integrity sha512-REe3k56GECRfDaqFjC8cwLhV4RxXmV0RubuzDJqwior9wlJcdHlN0qfW0tvUX+qphikaTQegIeRuhjRIAqkjkw==
 
-bulma@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.8.0.tgz#ac1606431703a4761b18a4a2d5cc1fa864a2aece"
-  integrity sha512-nhf3rGyiZh/VM7FrSJ/5KeLlfaFkXz0nYcXriynfPH4vVpnxnqyEwaNGdNCVzHyyCA3cHgkQAMpdF/SFbFGZfA==
+bulma@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.9.3.tgz#ddccb7436ebe3e21bf47afe01d3c43a296b70243"
+  integrity sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g==
 
 bytes@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR builds on some functionality from the Changelog to allow embedded photo assets within the ArticleSection component of any learning center article. In doing so, it also upgrades our Bulma package to 0.9.0 to make use of some new [spacing utility classes](https://bulma.io/documentation/helpers/spacing-helpers/).