### PR TITLE
Limit number of learning center search requests

### DIFF
--- a/src/components/learning-center/learning-searchbar.tsx
+++ b/src/components/learning-center/learning-searchbar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import algoliasearch from "algoliasearch/lite";
 import {
   InstantSearch,
@@ -20,30 +20,45 @@ const enableAnalytics = process.env.GATSBY_ENABLE_ALGOLIA_ANALYTICS;
 
 const SEARCH_RESULTS_LIMIT = 5;
 
-const SearchBox = ({ currentRefinement, refine, updateSearchQuery }: any) => (
-  <I18n>
-    {({ i18n }) => (
-      <form
-        className="control"
-        noValidate
-        action=""
-        role="search"
-        onSubmit={(e) => e.preventDefault()}
-      >
-        <input
-          className="input is-primary is-size-5"
-          type="search"
-          placeholder={i18n._(t`Search articles...`)}
-          value={currentRefinement}
-          onChange={(event) => {
-            refine(event.currentTarget.value);
-            updateSearchQuery(event.currentTarget.value);
-          }}
-        />
-      </form>
-    )}
-  </I18n>
-);
+const SearchBox = ({ currentRefinement, refine }: any) => {
+  return (
+    <>
+      <I18n>
+        {({ i18n }) => (
+          <form
+            className="control"
+            noValidate
+            action=""
+            role="search"
+            onSubmit={(e) => e.preventDefault()}
+          >
+            <input
+              className="input is-primary is-size-5"
+              type="search"
+              placeholder={i18n._(t`Search articles...`)}
+              value={currentRefinement}
+              onChange={(event) => {
+                refine(event.currentTarget.value);
+              }}
+            />
+          </form>
+        )}
+      </I18n>
+      {!!currentRefinement && (
+        <>
+          <CustomHits />
+          <div className="search-by is-pulled-right">
+            <img
+              width="100"
+              height="20"
+              src={require("../../img/brand/algolia.svg")}
+            />
+          </div>
+        </>
+      )}
+    </>
+  );
+};
 
 type SearchHitsProps = {
   hits?: {
@@ -97,7 +112,6 @@ const CustomSearchBox = connectSearchBox(SearchBox) as React.ComponentClass<
 const CustomHits = connectHits(SearchHits) as React.ComponentClass<Hits & any>;
 
 const LearningSearchBar = () => {
-  const [query, setQuery] = useState("");
   const locale = useCurrentLocale();
 
   return appId && searchKey ? (
@@ -109,28 +123,12 @@ const LearningSearchBar = () => {
         }
         resultsState={[]}
       >
-        <CustomSearchBox updateSearchQuery={(e: any) => setQuery(e)} />
-
-        {(query || "").length > 0 && (
-          <React.Fragment>
-            <Configure
-              attributesToSnippet={["articleContent"]}
-              analytics={enableAnalytics === "1" || false}
-            />
-            <CustomHits />
-          </React.Fragment>
-        )}
+        <Configure
+          attributesToSnippet={["articleContent"]}
+          analytics={enableAnalytics === "1" || false}
+        />
+        <CustomSearchBox />
       </InstantSearch>
-
-      {query && (
-        <div className="search-by is-pulled-right">
-          <img
-            width="100"
-            height="20"
-            src={require("../../img/brand/algolia.svg")}
-          />
-        </div>
-      )}
     </div>
   ) : (
     <React.Fragment />


### PR DESCRIPTION
This PR builds on some logic from https://github.com/JustFixNYC/who-owns-what/pull/633 making sure that we only send 1 network request to Algolia for each keystroke inputted in to our landlord name search bar. By consolidating some of our component logic, I was able to achieve a state where we only send one network request on rendering the search bar, one network request on every input character typed into the search bar, and don't send any requests on deleting characters or even typing already cached searches.

Note that this PR still costs 2 network requests when a user types in their first character—I wasn't able to figure out why this was happening but given that this search bar gets much less usage than WOW, I think it's ok to leave this in for now. 

This PR should leave the accessibility of the search bar unchanged.