### PR TITLE
Try redirecting all JustFix.org paths to current domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,3 +21,15 @@
   to = "https://www.justfix.nyc"
   status = 301
   force = true
+
+[[redirects]]
+  from = "https://justfix.org/*"
+  to = "https://www.justfix.nyc/:splat"
+  status = 302
+  force = true
+
+[[redirects]]
+  from = "https://www.justfix.org/*"
+  to = "https://www.justfix.nyc/:splat"
+  status = 302
+  force = true


### PR DESCRIPTION
This is a test to see if we can code in a wildcard redirect between two domains on the org site—in preparation for redirecting all `justfix.nyc` links to `justfix.org` links. 