### PR TITLE
Design dev page

### DIFF
--- a/src/pages/dev/design.en.tsx
+++ b/src/pages/dev/design.en.tsx
@@ -120,9 +120,18 @@ export const DevDesignPage = () => {
       </section>
       <section id="section-buttons" className="hero-body has-text">
         <h2 className="section-title">Buttons</h2>
-        <div id="button-samples">
+        <div id="button-samples" className="buttons">
           <button className="button is-primary">Primary</button>
           <button className="button is-secondary">Secondary</button>
+        </div>
+      </section>
+      <section id="section-pills" className="hero-body has-text">
+        <h2 className="section-title">Pills</h2>
+        <div id="pill-samples">
+          <span className="tag is-yellow">text</span>
+          <span className="tag is-blue">text</span>
+          <span className="tag is-pink">text</span>
+          <span className="tag is-empty">text</span>
         </div>
       </section>
       </div>

--- a/src/pages/dev/design.en.tsx
+++ b/src/pages/dev/design.en.tsx
@@ -7,133 +7,135 @@ export const DevDesignPage = () => {
   return (
     <Layout metadata={{ title: "JustFix Design System" }}>
       <div className="page-content">
-      <section className="hero-body">
-        <h1 className="title">JustFix Design System</h1>
-      </section>
-      <section id="section-palette" className="hero-body">
-        <h2 className="section-title">Color Palette</h2>
-        <div id="palette-swatches">
-          <div id="colors-box">
-            <div id="green-box">
-              <div className="color-info">
-                <p>Green</p>
-                <p>#1AA551</p>
-                <p>RGB 26 165 81</p>
-                <p>CMYK 82 8 96 0</p>
+        <section className="hero-body">
+          <h1 className="title">JustFix Design System</h1>
+        </section>
+        <section id="section-palette" className="hero-body">
+          <h2 className="section-title">Color Palette</h2>
+          <div id="palette-swatches">
+            <div id="colors-box">
+              <div id="green-box">
+                <div className="color-info">
+                  <p>Green</p>
+                  <p>#1AA551</p>
+                  <p>RGB 26 165 81</p>
+                  <p>CMYK 82 8 96 0</p>
+                </div>
+              </div>
+              <div id="pink-box">
+                <div className="color-info">
+                  <p>Pink</p>
+                  <p>#FFA0C7</p>
+                  <p>RGB 255 160 199</p>
+                  <p>CMYK 0 48 0 0 </p>
+                </div>
+              </div>
+              <div id="yellow-box">
+                <div className="color-info">
+                  <p>Yellow</p>
+                  <p>#FFBA33</p>
+                  <p>RGB 255 186 51</p>
+                  <p>CMYK 0 30 90 </p>
+                </div>
+              </div>
+              <div id="orange-box">
+                <div className="color-info">
+                  <p>Orange</p>
+                  <p>#FF813A</p>
+                  <p>RGB 255 129 58</p>
+                  <p>CMYK 0 61 84 0 </p>
+                </div>
+              </div>
+              <div id="blue-box">
+                <div className="color-info">
+                  <p>Blue</p>
+                  <p>#5188FF</p>
+                  <p>RGB 81 136 255 </p>
+                  <p>CMYK 65 42 0 0 </p>
+                </div>
               </div>
             </div>
-            <div id="pink-box">
-              <div className="color-info">
-                <p>Pink</p>
-                <p>#FFA0C7</p>
-                <p>RGB 255 160 199</p>
-                <p>CMYK 0 48 0 0 </p>
+            <div id="greyscale-box">
+              <div id="white-box">
+                <div className="color-info">
+                  <p>Off White</p>
+                  <p>#FAF8F4</p>
+                  <p>RGB 250 248 244</p>
+                  <p>CMYK 1 1 3 0 </p>
+                </div>
               </div>
-            </div>
-            <div id="yellow-box">
-              <div className="color-info">
-                <p>Yellow</p>
-                <p>#FFBA33</p>
-                <p>RGB 255 186 51</p>
-                <p>CMYK 0 30 90 </p>
+              <div id="grey-light-box">
+                <div className="color-info">
+                  <p>Light Gray</p>
+                  <p>#D4D5D0</p>
+                  <p>RGB 212 213 208</p>
+                  <p>CMYK 0 0 2 16</p>
+                </div>
               </div>
-            </div>
-            <div id="orange-box">
-              <div className="color-info">
-                <p>Orange</p>
-                <p>#FF813A</p>
-                <p>RGB 255 129 58</p>
-                <p>CMYK 0 61 84 0 </p>
+              <div id="grey-dark-box">
+                <div className="color-info">
+                  <p>Dark Gray</p>
+                  <p>#676565</p>
+                  <p>RGB 103 101 101 </p>
+                  <p>CMYK 0 1 1 60 </p>
+                </div>
               </div>
-            </div>
-            <div id="blue-box">
-              <div className="color-info">
-                <p>Blue</p>
-                <p>#5188FF</p>
-                <p>RGB 81 136 255 </p>
-                <p>CMYK 65 42 0 0 </p>
+              <div id="black-box">
+                <div className="color-info">
+                  <p>Off Black</p>
+                  <p>#242323</p>
+                  <p>RGB 35 35 35</p>
+                  <p>CMYK 71 66 64 72</p>
+                </div>
               </div>
             </div>
           </div>
-          <div id="greyscale-box">
-            <div id="white-box">
-              <div className="color-info">
-                <p>Off White</p>
-                <p>#FAF8F4</p>
-                <p>RGB 250 248 244</p>
-                <p>CMYK 1 1 3 0 </p>
-              </div>
+        </section>
+        <section id="section-typography" className="hero-body has-text">
+          <h2 className="section-title">Typography</h2>
+          <div id="type-samples">
+            <div id="desktop-text">
+              <h1>h1_desktop</h1>
+              <h2>H2_desktop</h2>
+              <h3>H3_desktop</h3>
+              <h4>H4_desktop</h4>
+              <p>Body_Standard_Desktop</p>
+              <a>Body-Standard-Link_Desktop</a>
+              <p className="is-small">Small-Text_Desktop</p>
+              <p className="is-small is-bold">Small-Text-Bold_Desktop</p>
+              <p className="eyebrow">Eyebrow_Large_Desktop</p>
+              <p className="eyebrow is-small">Eyebrow_Small_Desktop</p>
             </div>
-            <div id="grey-light-box">
-              <div className="color-info">
-                <p>Light Gray</p>
-                <p>#D4D5D0</p>
-                <p>RGB 212 213 208</p>
-                <p>CMYK 0 0 2 16</p>
-              </div>
-            </div>
-            <div id="grey-dark-box">
-              <div className="color-info">
-                <p>Dark Gray</p>
-                <p>#676565</p>
-                <p>RGB 103 101 101 </p>
-                <p>CMYK 0 1 1 60 </p>
-              </div>
-            </div>
-            <div id="black-box">
-              <div className="color-info">
-                <p>Off Black</p>
-                <p>#242323</p>
-                <p>RGB 35 35 35</p>
-                <p>CMYK 71 66 64 72</p>
-              </div>
+            <div id="mobile-text">
+              <h1>h1_mobile</h1>
+              <h2>h2_mobile</h2>
+              <h3>h3_mobile</h3>
+              <p>body-standard_mobile</p>
+              <a className="link">body-standard-link_mobile</a>
+              <p className="is-small">small-text_mobile</p>
+              <p className="is-small link">small-text-link_mobile</p>
+              <p className="is-small link is-bold">
+                small-text-bold-link_mobile
+              </p>
             </div>
           </div>
-        </div>
-      </section>
-      <section id="section-typography" className="hero-body has-text">
-        <h2 className="section-title">Typography</h2>
-        <div id="type-samples">
-          <div id="desktop-text">
-            <h1>h1_desktop</h1>
-            <h2>H2_desktop</h2>
-            <h3>H3_desktop</h3>
-            <h4>H4_desktop</h4>
-            <p>Body_Standard_Desktop</p>
-            <a>Body-Standard-Link_Desktop</a>
-            <p className="is-small">Small-Text_Desktop</p>
-            <p className="is-small is-bold">Small-Text-Bold_Desktop</p>
-            <p className="eyebrow">Eyebrow_Large_Desktop</p>
-            <p className="eyebrow is-small">Eyebrow_Small_Desktop</p>
+        </section>
+        <section id="section-buttons" className="hero-body has-text">
+          <h2 className="section-title">Buttons</h2>
+          <div id="button-samples" className="buttons">
+            <button className="button is-primary">Primary</button>
+            <button className="button is-secondary">Secondary</button>
           </div>
-          <div id="mobile-text">
-            <h1>h1_mobile</h1>
-            <h2>h2_mobile</h2>
-            <h3>h3_mobile</h3>
-            <p>body-standard_mobile</p>
-            <a className="link">body-standard-link_mobile</a>
-            <p className="is-small">small-text_mobile</p>
-            <p className="is-small link">small-text-link_mobile</p>
-            <p className="is-small link is-bold">small-text-bold-link_mobile</p>
+        </section>
+        <section id="section-pills" className="hero-body has-text">
+          <h2 className="section-title">Pills</h2>
+          <div id="pill-samples">
+            <span className="tag is-yellow">text</span>
+            <span className="tag is-blue">text</span>
+            <span className="tag is-pink">text</span>
+            <span className="tag is-empty">text</span>
           </div>
-        </div>
-      </section>
-      <section id="section-buttons" className="hero-body has-text">
-        <h2 className="section-title">Buttons</h2>
-        <div id="button-samples" className="buttons">
-          <button className="button is-primary">Primary</button>
-          <button className="button is-secondary">Secondary</button>
-        </div>
-      </section>
-      <section id="section-pills" className="hero-body has-text">
-        <h2 className="section-title">Pills</h2>
-        <div id="pill-samples">
-          <span className="tag is-yellow">text</span>
-          <span className="tag is-blue">text</span>
-          <span className="tag is-pink">text</span>
-          <span className="tag is-empty">text</span>
-        </div>
-      </section>
+        </section>
       </div>
     </Layout>
   );

--- a/src/pages/dev/design.en.tsx
+++ b/src/pages/dev/design.en.tsx
@@ -14,7 +14,7 @@ export const DevDesignPage = () => {
         <h2 className="section-title">Color Palette</h2>
         <div id="palette-swatches">
           <div id="colors-box">
-            <div className="color-box bg-jf-green">
+            <div id="green-box">
               <div className="color-info">
                 <p>Green</p>
                 <p>#1AA551</p>
@@ -22,7 +22,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 82 8 96 0</p>
               </div>
             </div>
-            <div className="color-box bg-jf-pink">
+            <div id="pink-box">
               <div className="color-info">
                 <p>Pink</p>
                 <p>#FFA0C7</p>
@@ -30,7 +30,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 48 0 0 </p>
               </div>
             </div>
-            <div className="bg-jf-yellow">
+            <div id="yellow-box">
               <div className="color-info">
                 <p>Yellow</p>
                 <p>#FFBA33</p>
@@ -38,7 +38,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 30 90 </p>
               </div>
             </div>
-            <div className="bg-jf-orange">
+            <div id="orange-box">
               <div className="color-info">
                 <p>Orange</p>
                 <p>#FF813A</p>
@@ -46,7 +46,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 61 84 0 </p>
               </div>
             </div>
-            <div className="bg-jf-blue">
+            <div id="blue-box">
               <div className="color-info">
                 <p>Blue</p>
                 <p>#5188FF</p>
@@ -56,7 +56,7 @@ export const DevDesignPage = () => {
             </div>
           </div>
           <div id="greyscale-box">
-            <div className="bg-jf-white">
+            <div id="white-box">
               <div className="color-info">
                 <p>Off White</p>
                 <p>#FAF8F4</p>
@@ -64,7 +64,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 1 1 3 0 </p>
               </div>
             </div>
-            <div className="bg-jf-grey-light">
+            <div id="grey-light-box">
               <div className="color-info">
                 <p>Light Gray</p>
                 <p>#D4D5D0</p>
@@ -72,7 +72,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 0 2 16</p>
               </div>
             </div>
-            <div className="bg-jf-grey-dark">
+            <div id="grey-dark-box">
               <div className="color-info">
                 <p>Dark Gray</p>
                 <p>#676565</p>
@@ -80,7 +80,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 1 1 60 </p>
               </div>
             </div>
-            <div className="bg-jf-black">
+            <div id="black-box">
               <div className="color-info">
                 <p>Off Black</p>
                 <p>#242323</p>

--- a/src/pages/dev/design.en.tsx
+++ b/src/pages/dev/design.en.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import Layout from "../../components/layout";
+
+import "../../styles/dev-design.scss";
+
+export const DevDesignPage = () => {
+  return (
+    <Layout metadata={{ title: "Page Not Found" }}>
+      <section className="hero-body">
+        <h1 className="section-title">JustFix Design System</h1>
+      </section>
+      <section id="section-palette" className="hero-body">
+        <h2 className="section-title">Color Palette</h2>
+        <div id="palette-swatches">
+          <div id="colors-box">
+            <div className="color-box jf-green">
+              <div className="color-info">
+                <p>Green</p>
+                <p>#1AA551</p>
+                <p>RGB 26 165 81</p>
+                <p>CMYK 82 8 96 0</p>
+              </div>
+            </div>
+            <div className="color-box jf-pink">
+              <div className="color-info">
+                <p>Pink</p>
+                <p>#FFA0C7</p>
+                <p>RGB 255 160 199</p>
+                <p>CMYK 0 48 0 0 </p>
+              </div>
+            </div>
+            <div className="jf-yellow">
+              <div className="color-info">
+                <p>Yellow</p>
+                <p>#FFBA33</p>
+                <p>RGB 255 186 51</p>
+                <p>CMYK 0 30 90 </p>
+              </div>
+            </div>
+            <div className="jf-orange">
+              <div className="color-info">
+                <p>Orange</p>
+                <p>#FF813A</p>
+                <p>RGB 255 129 58</p>
+                <p>CMYK 0 61 84 0 </p>
+              </div>
+            </div>
+            <div className="jf-blue">
+              <div className="color-info">
+                <p>Blue</p>
+                <p>#5188FF</p>
+                <p>RGB 81 136 255 </p>
+                <p>CMYK 65 42 0 0 </p>
+              </div>
+            </div>
+          </div>
+          <div id="greyscale-box">
+            <div className="jf-white">
+              <div className="color-info">
+                <p>Off White</p>
+                <p>#FAF8F4</p>
+                <p>RGB 250 248 244</p>
+                <p>CMYK 1 1 3 0 </p>
+              </div>
+            </div>
+            <div className="jf-grey-light">
+              <div className="color-info">
+                <p>Light Gray</p>
+                <p>#D4D5D0</p>
+                <p>RGB 212 213 208</p>
+                <p>CMYK 0 0 2 16</p>
+              </div>
+            </div>
+            <div className="jf-grey-dark">
+              <div className="color-info">
+                <p>Dark Gray</p>
+                <p>#676565</p>
+                <p>RGB 103 101 101 </p>
+                <p>CMYK 0 1 1 60 </p>
+              </div>
+            </div>
+            <div className="jf-black">
+              <div className="color-info">
+                <p>Off Black</p>
+                <p>#242323</p>
+                <p>RGB 35 35 35</p>
+                <p>CMYK 71 66 64 72</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section id="section-typography" className="hero-body has-text">
+        <h2 className="section-title">Typography</h2>
+        <div id="type-samples">
+          <div id="desktop-text">
+            <h1>h1_desktop</h1>
+            <h2>H2_desktop</h2>
+            <h3>H3_desktop</h3>
+            <h4>H4_desktop</h4>
+            <p>Body_Standard_Desktop</p>
+            <a>Body-Standard-Link_Desktop</a>
+            <p className="is-small">Small-Text_Desktop</p>
+            <p className="is-small is-bold">Small-Text-Bold_Desktop</p>
+            <p className="eyebrow">Eyebrow_Large_Desktop</p>
+            <p className="eyebrow is-small">Eyebrow_Small_Desktop</p>
+          </div>
+          <div id="mobile-text">
+            <h1>h1_mobile</h1>
+            <h2>h2_mobile</h2>
+            <h3>h3_mobile</h3>
+            <p>body-standard_mobile</p>
+            <a className="link">body-standard-link_mobile</a>
+            <p className="is-small">small-text_mobile</p>
+            <p className="is-small link">small-text-link_mobile</p>
+            <p className="is-small link is-bold">small-text-bold-link_mobile</p>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+};
+export default DevDesignPage;

--- a/src/pages/dev/design.en.tsx
+++ b/src/pages/dev/design.en.tsx
@@ -5,15 +5,16 @@ import "../../styles/dev-design.scss";
 
 export const DevDesignPage = () => {
   return (
-    <Layout metadata={{ title: "Page Not Found" }}>
+    <Layout metadata={{ title: "JustFix Design System" }}>
+      <div className="page-content">
       <section className="hero-body">
-        <h1 className="section-title">JustFix Design System</h1>
+        <h1 className="title">JustFix Design System</h1>
       </section>
       <section id="section-palette" className="hero-body">
         <h2 className="section-title">Color Palette</h2>
         <div id="palette-swatches">
           <div id="colors-box">
-            <div className="color-box jf-green">
+            <div className="color-box bg-jf-green">
               <div className="color-info">
                 <p>Green</p>
                 <p>#1AA551</p>
@@ -21,7 +22,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 82 8 96 0</p>
               </div>
             </div>
-            <div className="color-box jf-pink">
+            <div className="color-box bg-jf-pink">
               <div className="color-info">
                 <p>Pink</p>
                 <p>#FFA0C7</p>
@@ -29,7 +30,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 48 0 0 </p>
               </div>
             </div>
-            <div className="jf-yellow">
+            <div className="bg-jf-yellow">
               <div className="color-info">
                 <p>Yellow</p>
                 <p>#FFBA33</p>
@@ -37,7 +38,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 30 90 </p>
               </div>
             </div>
-            <div className="jf-orange">
+            <div className="bg-jf-orange">
               <div className="color-info">
                 <p>Orange</p>
                 <p>#FF813A</p>
@@ -45,7 +46,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 61 84 0 </p>
               </div>
             </div>
-            <div className="jf-blue">
+            <div className="bg-jf-blue">
               <div className="color-info">
                 <p>Blue</p>
                 <p>#5188FF</p>
@@ -55,7 +56,7 @@ export const DevDesignPage = () => {
             </div>
           </div>
           <div id="greyscale-box">
-            <div className="jf-white">
+            <div className="bg-jf-white">
               <div className="color-info">
                 <p>Off White</p>
                 <p>#FAF8F4</p>
@@ -63,7 +64,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 1 1 3 0 </p>
               </div>
             </div>
-            <div className="jf-grey-light">
+            <div className="bg-jf-grey-light">
               <div className="color-info">
                 <p>Light Gray</p>
                 <p>#D4D5D0</p>
@@ -71,7 +72,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 0 2 16</p>
               </div>
             </div>
-            <div className="jf-grey-dark">
+            <div className="bg-jf-grey-dark">
               <div className="color-info">
                 <p>Dark Gray</p>
                 <p>#676565</p>
@@ -79,7 +80,7 @@ export const DevDesignPage = () => {
                 <p>CMYK 0 1 1 60 </p>
               </div>
             </div>
-            <div className="jf-black">
+            <div className="bg-jf-black">
               <div className="color-info">
                 <p>Off Black</p>
                 <p>#242323</p>
@@ -117,6 +118,14 @@ export const DevDesignPage = () => {
           </div>
         </div>
       </section>
+      <section id="section-buttons" className="hero-body has-text">
+        <h2 className="section-title">Buttons</h2>
+        <div id="button-samples">
+          <button className="button is-primary">Primary</button>
+          <button className="button is-secondary">Secondary</button>
+        </div>
+      </section>
+      </div>
     </Layout>
   );
 };

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -142,19 +142,23 @@ $family-primary: $body-font;
     @include link();
   }
 
-  .title.is-1, h1 {
+  .title.is-1,
+  h1 {
     @include desktop-h1();
   }
 
-  .title.is-2, h2 {
+  .title.is-2,
+  h2 {
     @include desktop-h2();
   }
 
-  .title.is-3, h3 {
+  .title.is-3,
+  h3 {
     @include desktop-h3();
   }
 
-  .title.is-4, h4 {
+  .title.is-4,
+  h4 {
     @include desktop-h4();
   }
 
@@ -238,15 +242,18 @@ $family-primary: $body-font;
     @include link();
   }
 
-  .title.is-1, h1 {
+  .title.is-1,
+  h1 {
     @include mobile-h1();
   }
 
-  .title.is-2, h2 {
+  .title.is-2,
+  h2 {
     @include mobile-h2();
   }
 
-  .title.is-3, h3 {
+  .title.is-3,
+  h3 {
     @include mobile-h3();
   }
 
@@ -337,8 +344,7 @@ $family-primary: $body-font;
 
 // PILLS:
 
-
-.tag, 
+.tag,
 .tag:not(body) {
   @include mobile-text-small-bold;
   letter-spacing: 0.02rem;
@@ -348,7 +354,7 @@ $family-primary: $body-font;
   gap: 0.625rem;
 
   // this is 12px/0.75rem in mocks, but it looks too sqaure - not sure how/why
-  border-radius: 1rem; 
+  border-radius: 1rem;
 
   &.is-yellow {
     background: $justfix-yellow;

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -285,6 +285,7 @@ $family-primary: $body-font;
   height: fit-content;
   // IE support:
   display: table;
+  flex: none;
   box-shadow: 0.25rem 0.25rem 0rem $justfix-grey-light;
   max-width: 100%;
   white-space: normal;
@@ -336,21 +337,18 @@ $family-primary: $body-font;
 
 // PILLS:
 
-.tag {
+
+.tag, 
+.tag:not(body) {
   @include mobile-text-small-bold;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 0.25rem 0.375rem;
+  letter-spacing: 0.02rem;
+  text-transform: uppercase;
+  padding: 0.25rem 0.5rem;
+  margin: 0.25rem;
   gap: 0.625rem;
 
-  position: absolute;
-  border-radius: 0.75rem;
-
-  &:not(body) {
-    border-radius: 0.75rem;
-  }
+  // this is 12px/0.75rem in mocks, but it looks too sqaure - not sure how/why
+  border-radius: 1rem; 
 
   &.is-yellow {
     background: $justfix-yellow;

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -61,7 +61,6 @@ $family-primary: $body-font;
 
 @mixin link {
   text-decoration: underline;
-  color: inherit;
 
   &:hover,
   &:focus,
@@ -72,14 +71,14 @@ $family-primary: $body-font;
 
 // TYPOGRAPHY-DESKTOP:
 @mixin desktop-h1 {
-  @include body-standard;
+  @include body-standard();
   font-family: $title-font;
   font-size: 6rem;
   letter-spacing: 0.03em;
 }
 
 @mixin desktop-h2 {
-  @include body-standard;
+  @include body-standard();
   font-family: $title-font;
   font-size: 4rem;
   line-height: 90%;
@@ -87,30 +86,30 @@ $family-primary: $body-font;
 }
 
 @mixin desktop-h3 {
-  @include body-standard;
+  @include body-standard();
   font-weight: 600;
   font-size: 2.25rem;
 }
 
 @mixin desktop-h4 {
-  @include body-standard;
+  @include body-standard();
   font-size: 1.5rem;
   line-height: 120%;
 }
 
 @mixin desktop-text-small {
-  @include body-standard;
+  @include body-standard();
   font-size: 0.875rem;
 }
 
 @mixin desktop-text-small-bold {
-  @include body-standard;
+  @include body-standard();
   font-weight: 600;
   letter-spacing: 0.02em;
 }
 
 @mixin desktop-eyebrow {
-  @include body-standard;
+  @include body-standard();
   font-family: $eyebrow-font;
   line-height: 115%;
   letter-spacing: 0.03em;
@@ -118,7 +117,7 @@ $family-primary: $body-font;
 }
 
 @mixin desktop-eyebrow-small {
-  @include desktop-eyebrow;
+  @include desktop-eyebrow();
   font-size: 1rem;
 }
 
@@ -127,61 +126,57 @@ $family-primary: $body-font;
   p,
   a,
   span {
-    @include body-standard;
+    @include body-standard();
 
-    .is-small {
-      @include desktop-text-small;
+    &.is-small {
+      @include desktop-text-small();
     }
 
     &.is-bold {
-      @include desktop-text-small-bold;
+      @include desktop-text-small-bold();
     }
   }
 
   a,
   .link {
-    @include link;
+    @include link();
   }
 
-  h1 {
-    @include desktop-h1;
+  .title.is-1, h1 {
+    @include desktop-h1();
   }
 
-  h2 {
-    @include desktop-h2;
+  .title.is-2, h2 {
+    @include desktop-h2();
   }
 
-  h3 {
-    @include desktop-h3;
+  .title.is-3, h3 {
+    @include desktop-h3();
   }
 
-  h4 {
-    @include desktop-h4;
+  .title.is-4, h4 {
+    @include desktop-h4();
   }
 
   .eyebrow {
-    @include desktop-eyebrow;
+    @include desktop-eyebrow();
 
     &.is-small {
-      @include desktop-eyebrow-small;
+      @include desktop-eyebrow-small();
     }
   }
-}
-
-@include desktop {
-  @include desktop-typography;
 }
 
 // TYPOGRAPHY-MOBILE:
 
 @mixin mobile-h1 {
-  @include body-standard;
+  @include body-standard();
   font-weight: 600;
   font-size: 2.25rem;
 }
 
 @mixin mobile-h2 {
-  @include body-standard;
+  @include body-standard();
   font-weight: 600;
   font-size: 1.125rem;
   letter-spacing: 0.02em;
@@ -189,13 +184,13 @@ $family-primary: $body-font;
 }
 
 @mixin mobile-h3 {
-  @include body-standard;
+  @include body-standard();
   font-size: 1.5rem;
   line-height: 110%;
 }
 
 @mixin mobile-eyebrow {
-  @include body-standard;
+  @include body-standard();
   font-size: 0.875rem;
   line-height: 115%;
   letter-spacing: 0.03em;
@@ -203,18 +198,18 @@ $family-primary: $body-font;
 }
 
 @mixin mobile-text-small {
-  @include body-standard;
+  @include body-standard();
   font-size: 0.875rem;
 }
 
 @mixin mobile-text-small-bold {
-  @include mobile-text-small;
+  @include mobile-text-small();
   font-weight: 600;
 }
 
 @mixin mobile-text-small-link {
-  @include mobile-text-small;
-  @include link;
+  @include mobile-text-small();
+  @include link();
   line-height: 115%;
 }
 
@@ -223,55 +218,117 @@ $family-primary: $body-font;
   p,
   a,
   span {
-    @include body-standard;
+    @include body-standard();
 
-    .is-small {
-      @include mobile-text-small;
+    &.is-small {
+      @include mobile-text-small();
 
       &.is-bold {
-        @include mobile-text-small-bold;
+        @include mobile-text-small-bold();
       }
     }
 
-    .is-large {
-      @include mobile-h3;
+    &.is-large {
+      @include mobile-h3();
     }
   }
 
   a,
   .link {
-    @include link;
+    @include link();
   }
 
-  h1 {
-    @include mobile-h1;
+  .title.is-1, h1 {
+    @include mobile-h1();
   }
 
-  h2 {
-    @include mobile-h2;
+  .title.is-2, h2 {
+    @include mobile-h2();
   }
 
-  h3 {
-    @include mobile-h3;
+  .title.is-3, h3 {
+    @include mobile-h3();
   }
 
   .eyebrow {
-    @include mobile-eyebrow;
+    @include mobile-eyebrow();
   }
 }
 
-@include mobile {
-  @include mobile-typography;
+.page-content {
+  @include desktop() {
+    @include desktop-typography();
+  }
+  @include mobile() {
+    @include mobile-typography();
+  }
 }
+
+// COLORS:
+
+
+.bg-jf-black {
+  background-color: $justfix-black;
+}
+
+.bg-jf-white {
+  background-color: $justfix-white;
+}
+
+.bg-jf-grey-light {
+  background-color: $justfix-grey-light;
+}
+
+.bg-jf-grey-dark {
+  background-color: $justfix-grey-dark;
+}
+
+.bg-jf-green {
+  background-color: $justfix-green;
+}
+
+.bg-jf-pink {
+  background-color: $justfix-pink;
+}
+
+.bg-jf-yellow {
+  background-color: $justfix-yellow;
+}
+
+.bg-jf-orange {
+  background-color: $justfix-orange;
+}
+
+.bg-jf-blue {
+  background-color: $justfix-blue;
+}
+
+
+.c-jf-black {
+  color: $justfix-black;
+}
+
+.c-jf-white {
+  color: $justfix-white;
+}
+
+.c-jf-grey-light {
+  color: $justfix-grey-light;
+}
+
+.c-jf-grey-dark {
+  color: $justfix-grey-dark;
+}
+
 
 // BUTTONS:
 
 // Override of Standard Mixin:
 @mixin button-variant($color: $justfix-black) {
   background-color: $color;
-  @include mobile-eyebrow;
+  @include mobile-eyebrow();
 
-  @if $color ==$justfix-white {
+  @if $color == $justfix-white {
     color: $justfix-black;
     border: 0.0625rem solid $justfix-black;
   } @else {
@@ -319,11 +376,13 @@ $family-primary: $body-font;
   }
 }
 
-.button.is-primary {
+.button.is-primary,
+.button.is-primary:not(.is-outlined) {
   @include button-variant($justfix-black);
 }
 
-.button.is-secondary {
+.button.is-secondary,
+.button.is-secondary:not(.is-outlined) {
   @include button-variant($justfix-white);
 }
 

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -47,9 +47,9 @@ $eyebrow-font: "Suisse Int'l Mono", "Courier New", Courier, monospace;
 
 $family-primary: $body-font;
 
-// TEXT:
+// TYPOGRAPHY:
 
-%body-standard {
+@mixin body-standard {
   font-family: $body-font;
   font-size: 1.125rem;
   line-height: 100%;
@@ -59,132 +59,209 @@ $family-primary: $body-font;
   color: $justfix-black;
 }
 
-%desktop-eyebrow {
-  @extend %body-standard;
+@mixin link {
+  text-decoration: underline;
+  color: inherit;
+
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: underline;
+  }
+}
+
+// TYPOGRAPHY-DESKTOP:
+@mixin desktop-h1 {
+  @include body-standard;
+  font-family: $title-font;
+  font-size: 6rem;
+  letter-spacing: 0.03em;
+}
+
+@mixin desktop-h2 {
+  @include body-standard;
+  font-family: $title-font;
+  font-size: 4rem;
+  line-height: 90%;
+  letter-spacing: 0.03em;
+}
+
+@mixin desktop-h3 {
+  @include body-standard;
+  font-weight: 600;
+  font-size: 2.25rem;
+}
+
+@mixin desktop-h4 {
+  @include body-standard;
+  font-size: 1.5rem;
+  line-height: 120%;
+}
+
+@mixin desktop-text-small {
+  @include body-standard;
+  font-size: 0.875rem;
+}
+
+@mixin desktop-text-small-bold {
+  @include body-standard;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+@mixin desktop-eyebrow {
+  @include body-standard;
   font-family: $eyebrow-font;
   line-height: 115%;
   letter-spacing: 0.03em;
   text-transform: uppercase;
-  &-small {
-    font-size: 1rem;
+}
+
+@mixin desktop-eyebrow-small {
+  @include desktop-eyebrow;
+  font-size: 1rem;
+}
+
+@mixin desktop-typography {
+  body,
+  p,
+  a,
+  span {
+    @include body-standard;
+
+    .is-small {
+      @include desktop-text-small;
+    }
+
+    &.is-bold {
+      @include desktop-text-small-bold;
+    }
+  }
+
+  a,
+  .link {
+    @include link;
+  }
+
+  h1 {
+    @include desktop-h1;
+  }
+
+  h2 {
+    @include desktop-h2;
+  }
+
+  h3 {
+    @include desktop-h3;
+  }
+
+  h4 {
+    @include desktop-h4;
+  }
+
+  .eyebrow {
+    @include desktop-eyebrow;
+
+    &.is-small {
+      @include desktop-eyebrow-small;
+    }
   }
 }
 
-%mobile-eyebrow {
-  @extend %body-standard;
+@include desktop {
+  @include desktop-typography;
+}
+
+// TYPOGRAPHY-MOBILE:
+
+@mixin mobile-h1 {
+  @include body-standard;
+  font-weight: 600;
+  font-size: 2.25rem;
+}
+
+@mixin mobile-h2 {
+  @include body-standard;
+  font-weight: 600;
+  font-size: 1.125rem;
+  letter-spacing: 0.02em;
+  font-variant: small-caps;
+}
+
+@mixin mobile-h3 {
+  @include body-standard;
+  font-size: 1.5rem;
+  line-height: 110%;
+}
+
+@mixin mobile-eyebrow {
+  @include body-standard;
   font-size: 0.875rem;
   line-height: 115%;
   letter-spacing: 0.03em;
   text-transform: uppercase;
 }
 
-%mobile-text {
-  @extend %body-standard;
-  &-large {
-    font-size: 1.5rem;
-    line-height: 110%;
-  }
-  &-small {
-    font-size: 0.875rem;
-    &-bold {
-      font-weight: 600;
-    }
-    &-link {
-      text-decoration-line: underline;
-      line-height: 115%;
-    }
-  }
+@mixin mobile-text-small {
+  @include body-standard;
+  font-size: 0.875rem;
 }
 
-body {
-  @extend %body-standard;
+@mixin mobile-text-small-bold {
+  @include mobile-text-small;
+  font-weight: 600;
+}
 
-  @include desktop {
-    h1 {
-      font-family: $title-font;
-      font-size: 6rem;
-      letter-spacing: 0.03em;
-    }
+@mixin mobile-text-small-link {
+  @include mobile-text-small;
+  @include link;
+  line-height: 115%;
+}
 
-    h2 {
-      font-family: $title-font;
-      font-size: 4rem;
-      line-height: 90%;
-      letter-spacing: 0.03em;
-    }
-
-    h3 {
-      font-weight: 600;
-      font-size: 2.25rem;
-    }
-
-    h4 {
-      font-size: 1.5rem;
-      line-height: 120%;
-    }
-
-    .link {
-      text-decoration-line: underline;
-    }
+@mixin mobile-typography {
+  body,
+  p,
+  a,
+  span {
+    @include body-standard;
 
     .is-small {
-      font-size: 0.875rem;
+      @include mobile-text-small;
 
       &.is-bold {
-        font-weight: 600;
-        letter-spacing: 0.02em;
+        @include mobile-text-small-bold;
       }
-    }
-
-    .eyebrow {
-      @extend %desktop-eyebrow;
-
-      &.is-small {
-        @extend %desktop-eyebrow-small;
-      }
-    }
-  }
-
-  @include mobile {
-    h1 {
-      font-weight: 600;
-      font-size: 2.25rem;
-    }
-
-    h2 {
-      font-weight: 600;
-      letter-spacing: 0.02em;
-      font-variant: small-caps;
-    }
-
-    h3 {
-      @extend %mobile-text-large;
-    }
-
-    .eyebrow {
-      @extend %mobile-eyebrow;
-    }
-
-    .link {
-      text-decoration-line: underline;
     }
 
     .is-large {
-      @extend %mobile-text-large;
-    }
-
-    .is-small {
-      @extend %mobile-text-small;
-
-      &.is-bold {
-        @extend %mobile-text-small-bold;
-      }
-
-      &.link {
-        @extend %mobile-text-small-link;
-      }
+      @include mobile-h3;
     }
   }
+
+  a,
+  .link {
+    @include link;
+  }
+
+  h1 {
+    @include mobile-h1;
+  }
+
+  h2 {
+    @include mobile-h2;
+  }
+
+  h3 {
+    @include mobile-h3;
+  }
+
+  .eyebrow {
+    @include mobile-eyebrow;
+  }
+}
+
+@include mobile {
+  @include mobile-typography;
 }
 
 // BUTTONS:
@@ -192,9 +269,9 @@ body {
 // Override of Standard Mixin:
 @mixin button-variant($color: $justfix-black) {
   background-color: $color;
-  @extend %mobile-eyebrow;
+  @include mobile-eyebrow;
 
-  @if $color == $justfix-white {
+  @if $color ==$justfix-white {
     color: $justfix-black;
     border: 0.0625rem solid $justfix-black;
   } @else {
@@ -221,18 +298,21 @@ body {
     border-color: initial;
     background-color: $color;
   }
+
   &:hover {
     transition: all 0.1s linear;
     box-shadow: 0rem 0.4375rem 0rem 0rem $justfix-grey-light;
     transform: translateX(0.4375rem);
   }
+
   &:active,
   &.active {
-    @if $color == $justfix-white {
+    @if $color ==$justfix-white {
       color: $justfix-black;
     } @else {
       color: $justfix-white;
     }
+
     border-style: solid;
     background-color: $color;
     box-shadow: inset 0rem 0.25rem 0rem $justfix-grey-light;
@@ -255,7 +335,7 @@ body {
 // PILLS:
 
 .tag {
-  @extend %mobile-text-small-bold;
+  @include mobile-text-small-bold;
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -264,63 +264,6 @@ $family-primary: $body-font;
   }
 }
 
-// COLORS:
-
-
-.bg-jf-black {
-  background-color: $justfix-black;
-}
-
-.bg-jf-white {
-  background-color: $justfix-white;
-}
-
-.bg-jf-grey-light {
-  background-color: $justfix-grey-light;
-}
-
-.bg-jf-grey-dark {
-  background-color: $justfix-grey-dark;
-}
-
-.bg-jf-green {
-  background-color: $justfix-green;
-}
-
-.bg-jf-pink {
-  background-color: $justfix-pink;
-}
-
-.bg-jf-yellow {
-  background-color: $justfix-yellow;
-}
-
-.bg-jf-orange {
-  background-color: $justfix-orange;
-}
-
-.bg-jf-blue {
-  background-color: $justfix-blue;
-}
-
-
-.c-jf-black {
-  color: $justfix-black;
-}
-
-.c-jf-white {
-  color: $justfix-white;
-}
-
-.c-jf-grey-light {
-  color: $justfix-grey-light;
-}
-
-.c-jf-grey-dark {
-  color: $justfix-grey-dark;
-}
-
-
 // BUTTONS:
 
 // Override of Standard Mixin:

--- a/src/styles/dev-design.scss
+++ b/src/styles/dev-design.scss
@@ -4,8 +4,10 @@
 @import "~bulma/sass/utilities/initial-variables.sass";
 
 @import "_vars.scss";
-@import "_design-system.scss";
+@import "_fonts.scss";
 @import "_custom.scss";
+@import "_design-system.scss";
+
 
 
 section {
@@ -26,14 +28,40 @@ section {
     padding: 10px;
   }
 
-  div div {
+}
 
-    &.bg-jf-black,
-    &.bg-jf-grey-dark {
-      p {
-        color: $justfix-white
-      }
-    }
+
+#green-box {
+  background-color: $justfix-green;
+}
+#pink-box {
+  background-color: $justfix-pink;
+}
+#yellow-box {
+  background-color: $justfix-yellow;
+}
+#orange-box {
+  background-color: $justfix-orange;
+}
+#blue-box {
+  background-color: $justfix-blue;
+}
+#white-box {
+  background-color: $justfix-white;
+}
+#grey-light-box {
+  background-color: $justfix-grey-light;
+}
+#grey-dark-box {
+  background-color: $justfix-grey-dark;
+}
+#black-box {
+  background-color: $justfix-black;
+}
+#black-box,
+#grey-dark-box {
+  p {
+    color: $justfix-white
   }
 }
 
@@ -58,8 +86,13 @@ section {
 
 // BUTTONS:
 
-#button-samples .button {
-  margin: 10px;
+#button-samples {
+  display: flex;
+  flex-wrap: wrap;
+
+  .button {
+    margin: 10px;
+  }
 }
 
 @import "~bulma/bulma.sass";

--- a/src/styles/dev-design.scss
+++ b/src/styles/dev-design.scss
@@ -8,8 +8,6 @@
 @import "_custom.scss";
 @import "_design-system.scss";
 
-
-
 section {
   background-color: $justfix-white  !important;
 }
@@ -86,14 +84,18 @@ section {
 
 // BUTTONS:
 
-#button-samples {
-  display: flex;
-  flex-wrap: wrap;
+// #button-samples {
+//   display: flex;
+//   flex-wrap: wrap;
 
-  .button {
-    margin: 10px;
-  }
-}
+//   .button {
+//     margin: 10px;
+//   }
+// }
 
-@import "~bulma/bulma.sass";
-@import "~bulma-divider";
+// // PILLS:
+
+// #pill-samples {
+//   display: flex;
+//   flex-wrap: wrap;
+// }

--- a/src/styles/dev-design.scss
+++ b/src/styles/dev-design.scss
@@ -1,0 +1,77 @@
+@import "./design-system";
+
+section {
+  background-color: $justfix-white !important;
+  .section-title {
+    padding: 10px;
+  }
+}
+
+// COLORS:
+
+div {
+  &.jf-black {
+    background-color: $justfix-black;
+  }
+
+  &.jf-white {
+    background-color: $justfix-white;
+  }
+
+  &.jf-grey-light {
+    background-color: $justfix-grey-light;
+  }
+
+  &.jf-grey-dark {
+    background-color: $justfix-grey-dark;
+  }
+
+  &.jf-green {
+    background-color: $justfix-green;
+  }
+
+  &.jf-pink {
+    background-color: $justfix-pink;
+  }
+
+  &.jf-yellow {
+    background-color: $justfix-yellow;
+  }
+
+  &.jf-orange {
+    background-color: $justfix-orange;
+  }
+
+  &.jf-blue {
+    background-color: $justfix-blue;
+  }
+}
+
+#palette-swatches {
+  display: flex;
+
+  div.jf-black,
+  div.jf-grey-dark {
+    color: $justfix-white;
+  }
+
+  .color-info {
+    padding: 10px;
+  }
+}
+
+// TYPOGRAPHY:
+
+#type-samples {
+  display: flex;
+  div {
+    padding: 10px;
+  }
+  #mobile-text {
+    @include mobile-typography;
+  }
+
+  #desktop-text {
+    @include desktop-typography;
+  }
+}

--- a/src/styles/dev-design.scss
+++ b/src/styles/dev-design.scss
@@ -9,7 +9,7 @@
 @import "_design-system.scss";
 
 section {
-  background-color: $justfix-white  !important;
+  background-color: $justfix-white !important;
 }
 
 .section-title {
@@ -18,16 +18,13 @@ section {
 
 // COLORS:
 
-
 #palette-swatches {
   display: flex;
 
   .color-info {
     padding: 10px;
   }
-
 }
-
 
 #green-box {
   background-color: $justfix-green;
@@ -59,7 +56,7 @@ section {
 #black-box,
 #grey-dark-box {
   p {
-    color: $justfix-white
+    color: $justfix-white;
   }
 }
 

--- a/src/styles/dev-design.scss
+++ b/src/styles/dev-design.scss
@@ -1,62 +1,39 @@
-@import "./design-system";
+@charset "utf-8";
+
+@import "../../node_modules/bulma/sass/utilities/functions.sass";
+@import "~bulma/sass/utilities/initial-variables.sass";
+
+@import "_vars.scss";
+@import "_design-system.scss";
+@import "_custom.scss";
+
 
 section {
-  background-color: $justfix-white !important;
-  .section-title {
-    padding: 10px;
-  }
+  background-color: $justfix-white  !important;
+}
+
+.section-title {
+  margin-bottom: 0.5rem;
 }
 
 // COLORS:
 
-div {
-  &.jf-black {
-    background-color: $justfix-black;
-  }
-
-  &.jf-white {
-    background-color: $justfix-white;
-  }
-
-  &.jf-grey-light {
-    background-color: $justfix-grey-light;
-  }
-
-  &.jf-grey-dark {
-    background-color: $justfix-grey-dark;
-  }
-
-  &.jf-green {
-    background-color: $justfix-green;
-  }
-
-  &.jf-pink {
-    background-color: $justfix-pink;
-  }
-
-  &.jf-yellow {
-    background-color: $justfix-yellow;
-  }
-
-  &.jf-orange {
-    background-color: $justfix-orange;
-  }
-
-  &.jf-blue {
-    background-color: $justfix-blue;
-  }
-}
 
 #palette-swatches {
   display: flex;
 
-  div.jf-black,
-  div.jf-grey-dark {
-    color: $justfix-white;
-  }
-
   .color-info {
     padding: 10px;
+  }
+
+  div div {
+
+    &.bg-jf-black,
+    &.bg-jf-grey-dark {
+      p {
+        color: $justfix-white
+      }
+    }
   }
 }
 
@@ -64,9 +41,12 @@ div {
 
 #type-samples {
   display: flex;
+  flex-wrap: wrap;
+
   div {
-    padding: 10px;
+    margin: 10px;
   }
+
   #mobile-text {
     @include mobile-typography;
   }
@@ -75,3 +55,12 @@ div {
     @include desktop-typography;
   }
 }
+
+// BUTTONS:
+
+#button-samples .button {
+  margin: 10px;
+}
+
+@import "~bulma/bulma.sass";
+@import "~bulma-divider";

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -6,6 +6,7 @@
 @import "_vars.scss";
 @import "_fonts.scss";
 @import "_custom.scss";
+@import "_design-system.scss";
 
 .home-page {
   .landing-image.hero.is-fullheight {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -3,6 +3,9 @@
 @import "../../node_modules/bulma/sass/utilities/functions.sass";
 @import "~bulma/sass/utilities/initial-variables.sass";
 
+@import "~bulma/bulma.sass";
+@import "~bulma-divider";
+
 @import "_vars.scss";
 @import "_fonts.scss";
 @import "_custom.scss";
@@ -73,6 +76,3 @@
     }
   }
 }
-
-@import "~bulma/bulma.sass";
-@import "~bulma-divider";


### PR DESCRIPTION
This PR first fixes some problems with the use of `%extend` in scss files, and refactors to use `@mixins` instead. 

Then it also adds the beginnings of a design display page (at `/dev/design`) for internal use, allowing everyone to look at live versions of all the implemented design system elements. 

Still TODO: make sure these dev pages only show up on demo sites. 