### PR TITLE
small fixes to design system and learning center border

### DIFF
--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -56,7 +56,6 @@ $family-primary: $body-font;
   font-weight: 400;
   font-style: normal;
   letter-spacing: 0.01rem;
-  color: $justfix-black;
 }
 
 @mixin link {
@@ -262,14 +261,14 @@ $family-primary: $body-font;
   }
 }
 
-.page-content {
-  @include desktop() {
-    @include desktop-typography();
-  }
-  @include mobile() {
-    @include mobile-typography();
-  }
+@include desktop() {
+  @include desktop-typography();
 }
+
+@include mobile() {
+  @include mobile-typography();
+}
+
 
 // BUTTONS:
 

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -269,7 +269,6 @@ $family-primary: $body-font;
   @include mobile-typography();
 }
 
-
 // BUTTONS:
 
 // Override of Standard Mixin:
@@ -277,7 +276,7 @@ $family-primary: $body-font;
   background-color: $color;
   @include mobile-eyebrow();
 
-  @if $color == $justfix-white {
+  @if $color ==$justfix-white {
     color: $justfix-black;
     border: 0.0625rem solid $justfix-black;
   } @else {
@@ -391,6 +390,7 @@ $family-primary: $body-font;
   margin-bottom: 0;
   padding-left: $spacing-09;
   padding-right: $spacing-09;
+
   @include mobile {
     padding-left: $spacing-06;
     padding-right: $spacing-06;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -40,10 +40,12 @@
       @include desktop {
         border-right: 1px solid $justfix-black;
       }
+
       @include mobile {
         border-bottom: 1px solid $justfix-black;
       }
     }
+
     .column.is-7 .column:not(:last-child) {
       border-bottom: 1px solid $justfix-black;
     }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -37,7 +37,12 @@
 .home-page {
   .jf-learning-center-preview {
     .column.is-5 {
-      border-right: 1px solid $justfix-black;
+      @include desktop {
+        border-right: 1px solid $justfix-black;
+      }
+      @include mobile {
+        border-bottom: 1px solid $justfix-black;
+      }
     }
     .column.is-7 .column:not(:last-child) {
       border-bottom: 1px solid $justfix-black;


### PR DESCRIPTION
I had mistakenly left in a color in the design system text styles. Also all the text styles were only applied within `.page-content`, but I think that was my misunderstanding when copying over legacy styles. 

Also, I noticed that when switching to mobile the border on the featured learning center article needs to flip from right to bottom.