### PR TITLE
Update the Contact Us and Subscribed to Newsletter pages on the org site

### DIFF
--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -94,7 +94,7 @@ class SubscribeWithoutI18n extends React.Component<
     return (
       <div>
         <form
-          className="jf-email-form is-horizontal-center field has-addons"
+          className="jf-email-form field has-addons"
           onSubmit={this.handleSubmit}
         >
           <div className="control is-expanded is-paddingless">

--- a/src/components/subscribe.tsx
+++ b/src/components/subscribe.tsx
@@ -89,7 +89,7 @@ class SubscribeWithoutI18n extends React.Component<
 
     // Default styling is for "footer"
     const defaultResponseTextClass =
-      location === "page" ? "has-text-grey-dark" : "has-text-white";
+      location === "page" ? "has-text-black" : "has-text-white";
 
     return (
       <div>

--- a/src/pages/contact-us.en.tsx
+++ b/src/pages/contact-us.en.tsx
@@ -12,39 +12,40 @@ import Subscribe from "../components/subscribe";
 export const ContactPageScaffolding = (props: ContentfulContent) => (
   <Layout metadata={props.content.metadata}>
     <div id="contact" className="contact-page">
-      <section className="hero is-medium">
-        <div className="hero-body has-text-centered is-horizontal-center content-wrapper">
-          <div className="container">
-            <h1 className="title is-size-2 has-text-grey-dark has-text-weight-normal is-spaced">
-              {props.content.pageTitle}
-            </h1>
-            <span className="is-size-5 has-text-grey-dark">
+      <div className="columns is-centered">
+        <div className="column is-12 py-11">
+          <h1>{props.content.pageTitle}</h1>
+          <div className="mt-5 mb-8">
+            <span className="title is-3">
               {documentToReactComponents(props.content.contactCta.json)}
             </span>
+          </div>
 
-            <div className="field">
-              {props.content.socialButtons.map((button: any, i: number) => (
-                <SocialIcon
-                  key={i}
-                  url={button.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  bgColor="#0096D7"
-                  style={{ height: 40, width: 40 }}
-                />
-              ))}
-            </div>
-
-            <h1 className="title is-size-4 has-text-grey-dark is-spaced ">
-              {props.content.mailingListTitle}
-            </h1>
-            <span className="subtitle has-text-grey-dark">
-              {props.content.mailingListSubtitle}
-            </span>
-            <Subscribe location="page" />
+          <div className="field">
+            {props.content.socialButtons.map((button: any, i: number) => (
+              <SocialIcon
+                key={i}
+                url={button.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mr-3 mb-3"
+                style={{ height: 40, width: 40 }}
+              />
+            ))}
           </div>
         </div>
-      </section>
+      </div>
+      <div className="columns is-centered has-background-info">
+        <div className="column is-12 py-11">
+          <h1>{props.content.mailingListTitle}</h1>
+          <div className="mt-5 mb-9">
+            <span className="title is-3">
+              <p>{props.content.mailingListSubtitle}</p>
+            </span>
+          </div>
+          <Subscribe location="page" />
+        </div>
+      </div>
     </div>
   </Layout>
 );

--- a/src/pages/subscribed.en.tsx
+++ b/src/pages/subscribed.en.tsx
@@ -7,28 +7,26 @@ import { ContentfulContent } from "./index.en";
 
 export const SubscribedPageScaffolding = (props: ContentfulContent) => (
   <Layout metadata={{ title: props.content.title }}>
-    <section className="hero is-small">
-      <div className="hero-body has-text-centered is-horizontal-center">
-        <div className="content content-wrapper tight">
-          <h1 className="title is-size-2 has-text-grey-dark has-text-weight-normal is-spaced">
-            {props.content.title}
-          </h1>
-          <span className="is-size-5">
+    <div className="columns is-multiline">
+      <div className="column is-12 pt-11">
+        <h1 className="mb-5">{props.content.title}</h1>
+        <div className="mb-5">
+          <span className="title is-3">
             {documentToReactComponents(props.content.description.json)}
           </span>
         </div>
-        <br />
-        <div className="container block content-wrapper tight">
-          <figure className="image">
-            <img src={props.content.teamPhoto.file.url} alt="" />
-          </figure>
-        </div>
-        <br />
-        <span className="is-size-5">
+      </div>
+      <div className="column is-8 is-12-mobile">
+        <figure className="image is-256x256 mb-5">
+          <img src={props.content.teamPhoto.file.url} alt="" />
+        </figure>
+      </div>
+      <div className="column is-12 pb-11">
+        <span className="title is-3">
           {documentToReactComponents(props.content.descriptionBelowPhoto.json)}
         </span>
       </div>
-    </section>
+    </div>
   </Layout>
 );
 

--- a/src/pages/subscribed.en.tsx
+++ b/src/pages/subscribed.en.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { StaticQuery, graphql } from "gatsby";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
+import Img from "gatsby-image/withIEPolyfill";
 
 import Layout from "../components/layout";
 import { ContentfulContent } from "./index.en";
@@ -18,7 +19,7 @@ export const SubscribedPageScaffolding = (props: ContentfulContent) => (
       </div>
       <div className="column is-8 is-12-mobile">
         <figure className="image is-256x256 mb-5">
-          <img src={props.content.teamPhoto.file.url} alt="" />
+          <Img fluid={props.content.teamPhoto.fluid} alt="" />
         </figure>
       </div>
       <div className="column is-12 pb-11">
@@ -38,8 +39,8 @@ export const SubscribedPageFragment = graphql`
         json
       }
       teamPhoto {
-        file {
-          url
+        fluid {
+          ...GatsbyContentfulFluid
         }
       }
       descriptionBelowPhoto {

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -213,6 +213,7 @@ $page-hero-offset: $spacing-06;
 }
 
 .jf-email-form {
+  max-width: 400px;
   .button {
     background-color: $justfix-black;
     color: $justfix-white;

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -211,3 +211,18 @@ $page-hero-offset: $spacing-06;
   height: 16px;
   transform: translateY(3px);
 }
+
+.jf-email-form {
+  .button {
+    background-color: $justfix-black;
+    color: $justfix-white;
+    border: 1px solid $justfix-white;
+
+    &:focus,
+    &:hover {
+      background-color: $justfix-white;
+      color: $justfix-black;
+      transition: all 0.1s linear;
+    }
+  }
+}

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -63,6 +63,8 @@ $body-color: $justfix-black;
 }
 
 @mixin link {
+  color: inherit;
+  font-size: inherit;
   text-decoration: underline;
 
   &.no-underline {

--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -5,18 +5,4 @@
   .button {
     height: $spacing-09;
   }
-  .jf-email-form {
-    .button {
-      background-color: $justfix-black;
-      color: $justfix-white;
-      border: 1px solid $justfix-white;
-
-      &:focus,
-      &:hover {
-        background-color: $justfix-white;
-        color: $justfix-black;
-        transition: all 0.1s linear;
-      }
-    }
-  }
 }


### PR DESCRIPTION
This PR adds some simple styling to the `/contact-us` and `/subscribed` pages on the org site to match the rest of the rebrand (although there aren't any official mocks to replicate).