### PR TITLE
Fix object reference issue when grabbing asset alt text

### DIFF
--- a/src/components/embedded-asset-node.tsx
+++ b/src/components/embedded-asset-node.tsx
@@ -68,7 +68,10 @@ export const EmbeddedAsset: React.FC<{
       fields.description &&
       (fields.description[locale] || fields.description[DEFAULT_LOCALE])) ||
     "";
-  const file = fields.file[locale] || fields.file[DEFAULT_LOCALE];
+  const file =
+    fields &&
+    fields.description &&
+    (fields.file[locale] || fields.file[DEFAULT_LOCALE]);
   if (!file) {
     throw new Error("No file information on embedded asset node!");
   }

--- a/src/components/embedded-asset-node.tsx
+++ b/src/components/embedded-asset-node.tsx
@@ -64,9 +64,10 @@ export const EmbeddedAsset: React.FC<{
   }
   const { fields } = node.data.target;
   const altText =
-    fields && fields.description
-      ? fields.description[locale] || fields.description[DEFAULT_LOCALE] || ""
-      : "";
+    (fields &&
+      fields.description &&
+      (fields.description[locale] || fields.description[DEFAULT_LOCALE])) ||
+    "";
   const file = fields.file[locale] || fields.file[DEFAULT_LOCALE];
   if (!file) {
     throw new Error("No file information on embedded asset node!");

--- a/src/components/embedded-asset-node.tsx
+++ b/src/components/embedded-asset-node.tsx
@@ -64,7 +64,7 @@ export const EmbeddedAsset: React.FC<{
   }
   const { fields } = node.data.target;
   const altText =
-    fields.description[locale] || fields.description[DEFAULT_LOCALE] || "";
+    fields.description ? (fields.description[locale] || fields.description[DEFAULT_LOCALE] || "") : "";
   const file = fields.file[locale] || fields.file[DEFAULT_LOCALE];
   if (!file) {
     throw new Error("No file information on embedded asset node!");

--- a/src/components/embedded-asset-node.tsx
+++ b/src/components/embedded-asset-node.tsx
@@ -64,7 +64,9 @@ export const EmbeddedAsset: React.FC<{
   }
   const { fields } = node.data.target;
   const altText =
-    fields && fields.description ? (fields.description[locale] || fields.description[DEFAULT_LOCALE] || "") : "";
+    fields && fields.description
+      ? fields.description[locale] || fields.description[DEFAULT_LOCALE] || ""
+      : "";
   const file = fields.file[locale] || fields.file[DEFAULT_LOCALE];
   if (!file) {
     throw new Error("No file information on embedded asset node!");

--- a/src/components/embedded-asset-node.tsx
+++ b/src/components/embedded-asset-node.tsx
@@ -64,7 +64,7 @@ export const EmbeddedAsset: React.FC<{
   }
   const { fields } = node.data.target;
   const altText =
-    fields.description ? (fields.description[locale] || fields.description[DEFAULT_LOCALE] || "") : "";
+    fields && fields.description ? (fields.description[locale] || fields.description[DEFAULT_LOCALE] || "") : "";
   const file = fields.file[locale] || fields.file[DEFAULT_LOCALE];
   if (!file) {
     throw new Error("No file information on embedded asset node!");


### PR DESCRIPTION
This quick PR fixes an error with our Netlify builds where we weren't thoroughly checking whether an asset's "description" field was null or not before assigning it to the asset's alt text. Sometimes folks will upload assets to Contentful without inputting the description field (and there's also no way to make that required), so this small change just fixes the logic of that check on our end so that our build doesn't break when someone forgets to include an description on a photo.
```
7:47:23 PM: Building static HTML failed for path "/es/learn/rent-history-101"
7:47:23 PM: See our docs page for more info on this error: https://gatsby.dev/debug-html
7:47:23 PM: 
7:47:23 PM:   65 |   const { fields } = node.data.target;
7:47:23 PM:   66 |   const altText =
7:47:23 PM: > 67 |     fields.description[locale] || fields.description[DEFAULT_LOCALE] || "";
7:47:23 PM:      |            ^
7:47:23 PM:   68 |   const file = fields.file[locale] || fields.file[DEFAULT_LOCALE];
7:47:23 PM:   69 |   if (!file) {
7:47:23 PM:   70 |     throw new Error("No file information on embedded asset node!");
7:47:23 PM: 
7:47:23 PM:   WebpackError: TypeError: Cannot read property 'description' of undefined
```