### PR TITLE
Use Gatsby <Img> tags for lazy loading

### DIFF
--- a/src/pages/press.en.tsx
+++ b/src/pages/press.en.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { StaticQuery, graphql } from "gatsby";
+import Img from "gatsby-image/withIEPolyfill";
 // import { documentToReactComponents } from "@contentful/rich-text-react-renderer"
 // import { Link } from 'gatsby'
 
@@ -54,9 +55,9 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
                 )}
                 <div className="media is-align-items-center mt-7 mb-6">
                   <figure className="media-left image is-48x48">
-                    <img
-                      className="is-rounded"
-                      src={press.logo.fluid.src}
+                    <Img
+                      fluid={press.logo.fluid}
+                      className="is-rounded img-centered"
                       alt={press.title}
                     />
                   </figure>

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -1,7 +1,6 @@
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
 import { Trans } from "@lingui/macro";
 import { graphql, StaticQuery } from "gatsby";
-import Img from "gatsby-image/withIEPolyfill";
 import React from "react";
 import Layout from "../components/layout";
 import PageHero from "../components/page-hero";
@@ -10,6 +9,7 @@ import localeConfig from "../util/locale-config.json";
 import { useCurrentLocale } from "../util/use-locale";
 import { ContentfulContent } from "./index.en";
 import classnames from "classnames";
+import Img from "gatsby-image/withIEPolyfill";
 
 import "../styles/reports.scss";
 
@@ -52,9 +52,7 @@ function formatDate(dateString: string, locale?: string): string {
 type EndorsementInfo = {
   userName: string;
   userImage: {
-    fluid: {
-      src: string;
-    };
+    fluid: any;
   };
   userLink: string;
   message: {
@@ -67,7 +65,11 @@ const Endorsement: React.FC<EndorsementInfo> = (props) => (
   <div className="mt-8 mt-6-mobile pb-5 pb-0-mobile">
     <div className="is-flex has-text-centered is-align-items-center">
       <figure className="image is-48x48">
-        <img className="is-rounded" src={props.userImage.fluid.src} alt="" />
+        <Img
+          fluid={props.userImage.fluid}
+          alt=""
+          className="is-rounded img-centered"
+        />
       </figure>
       <span className="is-small is-bold pl-5">
         {props.userName} <Trans>says:</Trans>

--- a/src/pages/team.en.tsx
+++ b/src/pages/team.en.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { graphql, StaticQuery } from "gatsby";
+import Img from "gatsby-image/withIEPolyfill";
 import Layout from "../components/layout";
 import PageHero from "../components/page-hero";
 import { ContentfulContent } from "./index.en";
@@ -13,9 +14,7 @@ type MemberCardInfo = {
     description: string;
   };
   photo: {
-    fluid: {
-      src: string;
-    };
+    fluid: any;
   };
   className?: string;
 };
@@ -23,11 +22,7 @@ type MemberCardInfo = {
 const MemberCard: React.FC<MemberCardInfo> = (props) => (
   <div className={`column is-9 ${props.className}`}>
     <figure className="image">
-      <img
-        className="is-rounded"
-        src={props.photo.fluid.src}
-        alt={props.name}
-      />
+      <Img fluid={props.photo.fluid} className="is-rounded" alt={props.name} />
     </figure>
     <div className="has-text-centered my-7">
       <h3>{props.name}</h3>
@@ -137,7 +132,7 @@ export const TeamPageFragment = graphql`
         }
         photo {
           fluid {
-            src
+            ...GatsbyContentfulFluid
           }
         }
       }
@@ -150,7 +145,7 @@ export const TeamPageFragment = graphql`
         }
         photo {
           fluid {
-            src
+            ...GatsbyContentfulFluid
           }
         }
       }

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -203,6 +203,12 @@ $page-hero-offset: $spacing-06;
   transform: translate(-50%, -50%);
 }
 
+// With Gatsby <Img> className goes on a div and the actual
+// <img> is nested within.
+div.is-rounded img {
+  border-radius: 50%;
+}
+
 .bold-shadow {
   text-shadow: 0.4px 0px 0.1px, -0.4px 0px 0.1px;
 }


### PR DESCRIPTION
This PR changes `<img>` to Gatsby's `<Img>` everywhere (except svg) to give us lazy loading. To make sure the bulma `is-rounded` still works despite the weird nesting that's introduced with Img, added some css to _custom.scss