### PR TITLE
Add contact us link to footer

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -51,11 +51,12 @@ const FooterLinksList: React.FC<{ links: LinkWithLabel[] }> = ({ links }) => {
   return (
     <div className="columns is-paddingless is-hidden-touch ml-0">
       {links.map((link, i) => {
-        if (i % 2 === 0) {
+        if (i % 3 === 0) {
           return (
-            <div className="column is-3 is-paddingless mx-0" key={i}>
+            <div className="column is-4 is-paddingless mx-0" key={i}>
               <FooterLink link={link} />
               {!!links[i + 1] && <FooterLink link={links[i + 1]} />}
+              {!!links[i + 2] && <FooterLink link={links[i + 2]} />}
             </div>
           );
         } else return;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -39,6 +39,7 @@ export const SITE_LINKS: LinkWithLabel[] = [
   ["/reports", <Trans>Research & Policy</Trans>],
   ["/learn", <Trans>Learning Center</Trans>],
   [CAREERS_PAGE_URL, <Trans>Careers</Trans>],
+  ["/contact-us", <Trans>Contact Us</Trans>],
 ];
 
 const MoratoriumBanner: React.FC<{}> = () => {
@@ -179,8 +180,6 @@ const Header: React.FC<{
               {SITE_LINKS.map((link, i) => (
                 <HeaderLink link={link} key={i} />
               ))}
-
-              <HeaderLink link={["/contact-us", <Trans>Contact Us</Trans>]} />
 
               <div className="navbar-item has-dropdown is-hoverable">
                 <a className="navbar-link is-uppercase no-underline">


### PR DESCRIPTION
This PR adjusts our list of links in the footer section to now have 3 columns with 3 links each, making room for the "Contact Us" page.