### PR TITLE
Add alternative format for the PageHero component 

### DIFF
--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Trans } from "@lingui/macro";
 import BackgroundImage from "gatsby-background-image";
+import ResponsiveElement from "./responsive-element";
 
 type PageHeroInfo = {
   pageName: string;
@@ -27,10 +28,16 @@ const PageHero: React.FC<PageHeroInfo> = ({
             backgroundPosition: "center bottom",
           }}
         />
-        <div className="column is-6 px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
+        <div className="column is-6 px-10 py-9 p-6-mobile is-flex is-align-items-flex-end">
           <div>
-            <div className="eyebrow is-large pb-4">{pageName}</div>
-            <h1 className="mt-4">{description}</h1>
+            <ResponsiveElement
+              desktop="h2"
+              touch="h1"
+              className="mb-9 mb-5-mobile"
+            >
+              {description}
+            </ResponsiveElement>
+            <div className="eyebrow is-large pt-4">{pageName}</div>
           </div>
         </div>
       </div>

--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -18,41 +18,49 @@ const PageHero: React.FC<PageHeroInfo> = ({
   image,
 }) => (
   <div className="jf-page-hero is-flex is-justify-content-flex-end has-background-black has-text-white">
-    <div className="columns is-marginless is-paddingless">
-      {image ? (
+    {image ? (
+      <div className="columns is-marginless is-paddingless">
         <BackgroundImage
-          className="column is-6 is-12-mobile"
+          className="column is-6"
           fluid={image.fluid}
           style={{
             backgroundPosition: "center bottom",
           }}
         />
-      ) : (
-        <div className="column is-9 is-12-mobile px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
+        <div className="column is-6 px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
           <div>
             <div className="eyebrow is-large pb-4">{pageName}</div>
             <h1 className="mt-4">{description}</h1>
           </div>
         </div>
-      )}
-      <div className="column is-3 is-12-mobile px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
-        <div>
-          <div className="eyebrow is-large pb-4">
-            <Trans>On this page</Trans>
+      </div>
+    ) : (
+      <div className="columns is-marginless is-paddingless">
+        <div className="column is-9 px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
+          <div>
+            <div className="eyebrow is-large pb-4">{pageName}</div>
+            <h1 className="mt-4">{description}</h1>
           </div>
-          <ul className="mt-4">
-            {onThisPageList.map((item: string, i: number) => (
-              <li
-                className="title is-3 has-text-white is-marginless pl-8"
-                key={i}
-              >
-                {item}
-              </li>
-            ))}
-          </ul>
+        </div>
+        <div className="column is-3 px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
+          <div>
+            <div className="eyebrow is-large pb-4">
+              <Trans>On this page</Trans>
+            </div>
+            <ul className="mt-4">
+              {onThisPageList.map((item: string, i: number) => (
+                <li
+                  className="title is-3 has-text-white is-marginless pl-8"
+                  key={i}
+                >
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
         </div>
       </div>
-    </div>
+    )}
   </div>
 );
 

--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -1,25 +1,40 @@
 import React from "react";
 import { Trans } from "@lingui/macro";
+import BackgroundImage from "gatsby-background-image";
 
 type PageHeroInfo = {
   pageName: string;
   description: string;
   onThisPageList: string[];
+  image?: {
+    fluid: any;
+  };
 };
 
 const PageHero: React.FC<PageHeroInfo> = ({
   pageName,
   description,
   onThisPageList,
+  image,
 }) => (
   <div className="jf-page-hero is-flex is-justify-content-flex-end has-background-black has-text-white">
     <div className="columns is-marginless is-paddingless">
-      <div className="column is-9 is-12-mobile px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
-        <div>
-          <div className="eyebrow is-large pb-4">{pageName}</div>
-          <h1 className="mt-4">{description}</h1>
+      {image ? (
+        <BackgroundImage
+          className="column is-6 is-12-mobile"
+          fluid={image.fluid}
+          style={{
+            backgroundPosition: "center bottom",
+          }}
+        />
+      ) : (
+        <div className="column is-9 is-12-mobile px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
+          <div>
+            <div className="eyebrow is-large pb-4">{pageName}</div>
+            <h1 className="mt-4">{description}</h1>
+          </div>
         </div>
-      </div>
+      )}
       <div className="column is-3 is-12-mobile px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
         <div>
           <div className="eyebrow is-large pb-4">

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -155,6 +155,12 @@ $page-hero-offset: $spacing-06;
   }
 
   .columns {
+    width: 100%;
+
+    .gatsby-image-wrapper {
+      min-height: 375px;
+    }
+
     .eyebrow {
       border-bottom: 1px solid $justfix-white;
     }

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -165,6 +165,12 @@ $page-hero-offset: $spacing-06;
       border-bottom: 1px solid $justfix-white;
     }
 
+    // Let's reverse the orientation of this eyeborow border on hero's with images:
+    .column.is-6 .eyebrow {
+      border-bottom: none;
+      border-top: 1px solid $justfix-white;
+    }
+
     .column:first-child {
       border-right: 1px solid $justfix-white;
 


### PR DESCRIPTION
This PR refactors our `<PageHero>` component to accept an optional `image` property and then render an alternative layout of the component to show the image. 

P.S. You can test out how the new page hero looks by adding 
```
image {
  fluid {
    ...GatsbyContentfulFluid
  }
}
```
inside the `pageHero` field in the graphql query for the REPORTS page.