### PR TITLE
Bring header menu above content on all pages

### DIFF
--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -52,6 +52,7 @@
       }
     }
     .navbar-menu {
+      // Make sure navbar menu appears above other page content:
       z-index: 100;
       position: absolute;
       right: 0;

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -52,6 +52,9 @@
       }
     }
     .navbar-menu {
+      z-index: 100;
+      position: absolute;
+      right: 0;
       @include desktop {
         width: 325px;
         box-sizing: border-box;


### PR DESCRIPTION
This PR fixes an issue where the navbar header menu appeared below certain page content—like images—making the links on the menu unreachable. 

BEFORE: 
<img width="849" alt="Screen Shot 2022-07-25 at 10 03 39 AM" src="https://user-images.githubusercontent.com/12834575/180800519-355a58a6-4f6e-4d9f-9259-cba3d63c431a.png">
<img width="863" alt="Screen Shot 2022-07-25 at 10 03 29 AM" src="https://user-images.githubusercontent.com/12834575/180800525-6f930664-17ed-401e-9979-85b2be2b7906.png">


AFTER: 
<img width="487" alt="image" src="https://user-images.githubusercontent.com/12834575/180800752-817dadef-0348-4d92-8b2b-23d21b5101e3.png">
