### PR TITLE
Add fixed button to bottom of viewport on mobile homepage

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -39,8 +39,6 @@ const catalogs: LocaleCatalogs = {
 export const formatImageUrlForSEO = (url: string) =>
   url.startsWith("//") ? encodeURI(`https:${url}`) : encodeURI(url);
 
-// import './layout.css'
-
 type Props = {
   metadata?: {
     [key: string]: any;

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -7,9 +7,13 @@ import { StaticQuery, graphql } from "gatsby";
 
 import Header from "./header";
 import Footer from "./footer";
-import { useCurrentLocale } from "../util/use-locale";
+import { removeLocaleFromPathname, useCurrentLocale } from "../util/use-locale";
 import localeConfig from "../util/locale-config.json";
 import { CookiesBanner } from "./cookies-banner";
+import { useLocation } from "@reach/router";
+import { LocaleLink } from "./locale-link";
+import { Trans } from "@lingui/macro";
+import classnames from "classnames";
 
 const favicon16 = require("../img/brand/favicon-16x16.png");
 const favicon32 = require("../img/brand/favicon-32x32.png");
@@ -75,6 +79,8 @@ const LayoutScaffolding = ({
   }
 
   const locale = useCurrentLocale() || localeConfig.DEFAULT_LOCALE;
+  const { pathname } = useLocation();
+  const isHomepage = removeLocaleFromPathname(pathname) === "";
 
   return (
     <I18nProvider language={locale} catalogs={catalogs}>
@@ -119,9 +125,20 @@ const LayoutScaffolding = ({
         <meta name="twitter:image:alt" content={title} />
       </Helmet>
       <Header isLandingPage={isLandingPage} />
-      <div>{children}</div>
-      <Footer />
-      <CookiesBanner />
+      <div className={classnames(isHomepage && "mb-12-mobile")}>
+        {children}
+        <Footer />
+      </div>
+      <div className="jf-footer-menu">
+        <CookiesBanner />
+        {isHomepage && (
+          <div className="has-background-black py-5 is-flex is-justify-content-center is-hidden-desktop">
+            <LocaleLink to="/tools" className="button is-primary">
+              <Trans>See our tools</Trans>
+            </LocaleLink>
+          </div>
+        )}
+      </div>
     </I18nProvider>
   );
 };

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -133,16 +133,16 @@ const LayoutScaffolding = ({
       >
         {children}
         <Footer />
-      </div>
-      <div className="jf-footer-menu">
-        <CookiesBanner />
-        {isHomepage && (
-          <div className="has-background-black py-5 is-flex is-justify-content-center is-hidden-desktop">
-            <LocaleLink to="/tools" className="button is-primary">
-              <Trans>See our tools</Trans>
-            </LocaleLink>
-          </div>
-        )}
+        <div className="jf-footer-menu">
+          <CookiesBanner />
+          {isHomepage && (
+            <div className="has-background-black py-5 is-flex is-justify-content-center is-hidden-desktop">
+              <LocaleLink to="/tools" className="button is-primary">
+                <Trans>See our tools</Trans>
+              </LocaleLink>
+            </div>
+          )}
+        </div>
       </div>
     </I18nProvider>
   );

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -125,7 +125,12 @@ const LayoutScaffolding = ({
         <meta name="twitter:image:alt" content={title} />
       </Helmet>
       <Header isLandingPage={isLandingPage} />
-      <div className={classnames(isHomepage && "mb-12-mobile")}>
+      <div
+        className={
+          // Add extra space at bottom of page for fixed footer button:
+          classnames(isHomepage && "mb-12-mobile")
+        }
+      >
         {children}
         <Footer />
       </div>

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -305,6 +305,7 @@ div.is-rounded img {
   }
 }
 
+// Content that stays fixed at the bottom of the viewport:
 .jf-footer-menu {
   width: 100%;
   position: fixed;

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -305,10 +305,13 @@ div.is-rounded img {
   }
 }
 
-.jf-cookies-banner {
+.jf-footer-menu {
+  width: 100%;
   position: fixed;
   bottom: 0;
-  width: 100%;
+}
+
+.jf-cookies-banner {
   border-top: 1px solid $justfix-black;
 
   img {

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -310,6 +310,7 @@ div.is-rounded img {
   width: 100%;
   position: fixed;
   bottom: 0;
+  z-index: 30;
 }
 
 .jf-cookies-banner {


### PR DESCRIPTION
This PR implements a fixed footer menu with a button that links to our tools page, only visible on mobile and tablet devices on the homepage: 

<img width="562" alt="image" src="https://user-images.githubusercontent.com/12834575/181098504-e4508f49-6ffe-4d00-9bf4-2a5e5dc33658.png">
