### PR TITLE
Remove banner thats blocking redeploys

### DIFF
--- a/src/pages/partners.en.tsx
+++ b/src/pages/partners.en.tsx
@@ -66,11 +66,6 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
         ))}
       </section>
 
-      <CollaborationBanner
-        title={props.content.collaborationBanner.title}
-        subtitle={props.content.collaborationBanner.description.description}
-      />
-
       <ReadMore
         title={props.content.readMore.title}
         link={props.content.readMore.link}
@@ -115,12 +110,6 @@ export const PartnersPageFragment = graphql`
           fluid {
             src
           }
-        }
-      }
-      collaborationBanner {
-        title
-        description {
-          description
         }
       }
       readMore {

--- a/src/pages/partners.en.tsx
+++ b/src/pages/partners.en.tsx
@@ -6,7 +6,6 @@ import "../styles/partners.scss";
 import Layout from "../components/layout";
 import ReadMore from "../components/read-more";
 import { ContentfulContent } from "./index.en";
-import { CollaborationBanner } from "../components/collaboration-banner";
 
 export const PartnersPageScaffolding = (props: ContentfulContent) => (
   <Layout metadata={props.content.metadata}>


### PR DESCRIPTION
This hotfix removes a banner from the partners page that is now incompatible with our new content model. This will make sure we can continue to deploy things to the demo site before our official launch of the rebrand. 