### PR TITLE
use gatsby FluidObject type instead of any

### DIFF
--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -2,13 +2,14 @@ import React from "react";
 import { Trans } from "@lingui/macro";
 import BackgroundImage from "gatsby-background-image";
 import ResponsiveElement from "./responsive-element";
+import { FluidObject } from "gatsby-image";
 
 type PageHeroInfo = {
   pageName: string;
   description: string;
   onThisPageList: string[];
   image?: {
-    fluid: any;
+    fluid: FluidObject;
   };
 };
 

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -10,6 +10,7 @@ import { useCurrentLocale } from "../util/use-locale";
 import { ContentfulContent } from "./index.en";
 import Img from "gatsby-image/withIEPolyfill";
 import ResponsiveElement from "../components/responsive-element";
+import { FluidObject } from "gatsby-image";
 
 import "../styles/reports.scss";
 
@@ -25,7 +26,7 @@ function formatDate(dateString: string, locale?: string): string {
 type EndorsementInfo = {
   userName: string;
   userImage: {
-    fluid: any;
+    fluid: FluidObject;
   };
   userLink: string;
   message: {
@@ -62,7 +63,7 @@ type ReportCardInfo = {
   };
   reportUrl: string;
   image: {
-    fluid: any;
+    fluid: FluidObject;
   };
   endorsements: EndorsementInfo[];
   locale: string;

--- a/src/pages/team.en.tsx
+++ b/src/pages/team.en.tsx
@@ -4,6 +4,7 @@ import Img from "gatsby-image/withIEPolyfill";
 import Layout from "../components/layout";
 import PageHero from "../components/page-hero";
 import { ContentfulContent } from "./index.en";
+import { FluidObject } from "gatsby-image";
 
 import "../styles/team.scss";
 
@@ -14,7 +15,7 @@ type MemberCardInfo = {
     description: string;
   };
   photo: {
-    fluid: any;
+    fluid: FluidObject;
   };
   className?: string;
 };


### PR DESCRIPTION
This PR makes sure we are consistently using the gatsby `FluidObject` type instead of `any` when working with images from contentful graphql query