### PR TITLE
Update hero image aspect ratio on mobile

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -142,19 +142,17 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
 export const LandingPageScaffolding = (props: ContentfulContent) => (
   <Layout isLandingPage={true}>
     <div id="home" className="home-page">
-      <div className="my-8-mobile mt-12 mb-11">
-        <div className="columns">
-          <div className="column is-1" />
-          <div className="column is-10">
-            <h1>{props.content.landingLeadInText}</h1>
-          </div>
-        </div>
+      <div className="is-hidden-mobile">
+        <Img fluid={props.content.landingImage.fluid} alt="" />
       </div>
-
-      <div className="columns is-desktop is-centered">
-        <div className="column is-paddingless is-11 is-12-mobile">
-          <Img fluid={props.content.landingImage.fluid} alt="" />
-        </div>
+      <div className="is-hidden-tablet">
+        <Img
+          fluid={{
+            ...props.content.landingImage.fluid,
+            aspectRatio: 1,
+          }}
+          alt=""
+        />
       </div>
 
       <div className="has-background-black has-text-white">


### PR DESCRIPTION
[sc-10231]

- changed the hero image in contentful
- removed the text above the image per mocks
- added a mobile version with a 1:1 aspect ratio per mocks

looks like this:

<img width="952" alt="Screen Shot 2022-07-27 at 1 11 14 PM" src="https://user-images.githubusercontent.com/34112083/181363252-be1319c7-f892-4008-89a5-587a650f64d5.png"> <img width="347" alt="Screen Shot 2022-07-27 at 1 12 11 PM" src="https://user-images.githubusercontent.com/34112083/181363459-197fb49e-8b82-4a59-81fa-f35eb5d1cb4e.png">

