### PR TITLE
Remove page header rule on mobile, set to full width

### DIFF
--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -45,13 +45,13 @@ const PageHero: React.FC<PageHeroInfo> = ({
     ) : (
       <div className="columns is-marginless is-paddingless">
         <div className="column is-9 px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
-          <div>
+          <div className="is-flex-mobile is-flex-direction-column is-flex-grow-1">
             <div className="eyebrow is-large pb-4">{pageName}</div>
             <h1 className="mt-4">{description}</h1>
           </div>
         </div>
         <div className="column is-3 px-9 py-10 p-6-mobile is-flex is-align-items-flex-end">
-          <div>
+          <div className="is-flex-mobile is-flex-direction-column is-flex-grow-1">
             <div className="eyebrow is-large pb-4">
               <Trans>On this page</Trans>
             </div>

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -95,12 +95,12 @@ $spacing-values: (
 
 // OTHER BULMA OVERRIDES
 
-/* 
+/*
   Make sure descendants of the .title class inherit it's font size properties.
 
   This is especially helpful when using "Rich Text" type content from Contentful, which
   by default provides content in <p> tags. This rule makes sure we can override the size
-  of the text. 
+  of the text.
 */
 .title p {
   font-size: inherit;
@@ -180,11 +180,12 @@ $page-hero-offset: $spacing-06;
 
       @include mobile {
         border-right: none;
-        border-bottom: 2px solid $justfix-white;
       }
 
-      .eyebrow {
-        width: 50%;
+      @include desktop {
+        .eyebrow {
+          width: 50%;
+        }
       }
     }
 


### PR DESCRIPTION
[sc-10309]

mobile:
<img width="339" alt="Screen Shot 2022-07-27 at 1 28 51 PM" src="https://user-images.githubusercontent.com/34112083/181366118-97f44391-3580-4503-98b4-07899109e4ac.png">

desktop:
<img width="1125" alt="Screen Shot 2022-07-27 at 1 28 35 PM" src="https://user-images.githubusercontent.com/34112083/181366068-c54c0382-b39a-4291-b4d1-58f0d3f39fe4.png">
