### PR TITLE
QA fixes for navbar menu

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -235,7 +235,7 @@ const Header: React.FC<{
               <div className="navbar-end is-flex is-flex-direction-column py-3 px-5">
                 <div>
                   {SITE_LINKS.map((link, i) => (
-                    <HeaderLink link={link} key={i} className />
+                    <HeaderLink link={link} key={i} />
                   ))}
                 </div>
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -104,12 +104,15 @@ const MoratoriumBanner: React.FC<{}> = () => {
 
 const HeaderLink: React.FC<{ link: LinkWithLabel }> = ({ link }) =>
   link[0].charAt(0) === "/" ? (
-    <Link className="navbar-item no-underline p-0 has-text-white" to={link[0]}>
+    <Link
+      className="navbar-item no-underline px-0 py-3 has-text-white"
+      to={link[0]}
+    >
       {link[1]}
     </Link>
   ) : (
     <OutboundLink
-      className="navbar-item no-underline p-0 has-text-white"
+      className="navbar-item no-underline px-0 py-3 has-text-white"
       href={link[0]}
       target="_blank"
       rel="noopener noreferrer"
@@ -232,7 +235,7 @@ const Header: React.FC<{
               <div className="navbar-end is-flex is-flex-direction-column py-3 px-5">
                 <div>
                   {SITE_LINKS.map((link, i) => (
-                    <HeaderLink link={link} key={i} />
+                    <HeaderLink link={link} key={i} className />
                   ))}
                 </div>
 

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -22,7 +22,7 @@ export const CAREERS_PAGE_URL = "https://justfix.breezy.hr/";
 export type LinkWithLabel = [string, JSX.Element];
 
 export const SITE_LINKS: LinkWithLabel[] = [
-  ["/our-mission", <Trans>Mission</Trans>],
+  ["/our-mission", <Trans>What We Do</Trans>],
   ["/team", <Trans>Team</Trans>],
   ["/partners", <Trans>Partners & Funders</Trans>],
   ["/press", <Trans>Press</Trans>],
@@ -111,6 +111,8 @@ const HeaderLink: React.FC<{ link: LinkWithLabel }> = ({ link }) =>
     <OutboundLink
       className="navbar-item no-underline p-0 has-text-white"
       href={link[0]}
+      target="_blank"
+      rel="noopener noreferrer"
     >
       {link[1]}
     </OutboundLink>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -229,7 +229,7 @@ const Header: React.FC<{
                 (burgerMenuIsOpen && "is-active")
               }
             >
-              <div className="navbar-end is-flex is-flex-direction-column is-justify-content-space-between py-3 px-5">
+              <div className="navbar-end is-flex is-flex-direction-column py-3 px-5">
                 <div>
                   {SITE_LINKS.map((link, i) => (
                     <HeaderLink link={link} key={i} />

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -30,24 +30,24 @@ msgid "Assert your tenant rights by using our digital tools"
 msgstr ""
 
 #: src/components/learning-center/category-page-template.tsx:28
-msgid "Back to Overview"
-msgstr "Back to Overview"
+#~ msgid "Back to Overview"
+#~ msgstr "Back to Overview"
 
 #: src/components/cookies-banner.tsx:24
 msgid "By using our website you consent to the use of cookies."
 msgstr ""
 
-#: src/components/header.tsx:24
+#: src/components/header.tsx:25
 msgid "Careers"
 msgstr ""
 
 #: src/components/accordion.tsx:12
 #: src/components/cookies-banner.tsx:32
-#: src/components/header.tsx:86
+#: src/components/header.tsx:119
 msgid "Close"
 msgstr ""
 
-#: src/components/header.tsx:25
+#: src/components/header.tsx:26
 msgid "Contact Us"
 msgstr "Contact Us"
 
@@ -55,7 +55,7 @@ msgstr "Contact Us"
 msgid "Contents"
 msgstr ""
 
-#: src/components/header.tsx:69
+#: src/components/header.tsx:102
 msgid "DEMO SITE"
 msgstr "DEMO SITE"
 
@@ -87,19 +87,20 @@ msgstr "Join our mailing list!"
 msgid "Learn more"
 msgstr ""
 
-#: src/components/header.tsx:23
+#: src/components/header.tsx:24
 #: src/components/learning-center/article-template.tsx:74
+#: src/components/learning-center/category-page-template.tsx:14
 #: src/pages/learn.en.tsx:90
 msgid "Learning Center"
 msgstr ""
 
-#: src/components/header.tsx:86
+#: src/components/header.tsx:119
 msgid "Menu"
 msgstr ""
 
 #: src/components/header.tsx:17
-msgid "Mission"
-msgstr "Mission"
+#~ msgid "Mission"
+#~ msgstr "Mission"
 
 #: src/components/learning-center/learning-searchbar.tsx:73
 msgid "No articles match your search."
@@ -122,7 +123,7 @@ msgstr "Oops! A network error occurred. Try again later."
 msgid "Oops! That email is invalid."
 msgstr "Oops! That email is invalid."
 
-#: src/components/header.tsx:19
+#: src/components/header.tsx:20
 msgid "Partners & Funders"
 msgstr ""
 
@@ -134,7 +135,7 @@ msgstr ""
 msgid "Please enter an email address!"
 msgstr "Please enter an email address!"
 
-#: src/components/header.tsx:20
+#: src/components/header.tsx:21
 msgid "Press"
 msgstr "Press"
 
@@ -152,7 +153,7 @@ msgstr ""
 msgid "Read More"
 msgstr "Read More"
 
-#: src/components/header.tsx:22
+#: src/components/header.tsx:23
 msgid "Research & Policy"
 msgstr ""
 
@@ -164,7 +165,8 @@ msgstr ""
 msgid "See all articles"
 msgstr ""
 
-#: src/components/header.tsx:78
+#: src/components/header.tsx:111
+#: src/components/layout.tsx:100
 msgid "See our tools"
 msgstr ""
 
@@ -185,11 +187,11 @@ msgstr ""
 msgid "Take action"
 msgstr ""
 
-#: src/components/header.tsx:18
+#: src/components/header.tsx:19
 msgid "Team"
 msgstr "Team"
 
-#: src/components/header.tsx:73
+#: src/components/header.tsx:106
 msgid "Technology for Housing Justice"
 msgstr ""
 
@@ -209,7 +211,7 @@ msgstr ""
 msgid "This means that we’re able to see your approximate location, the type of device you’re using, and your operating system."
 msgstr ""
 
-#: src/components/header.tsx:21
+#: src/components/header.tsx:22
 msgid "Tools"
 msgstr ""
 
@@ -222,6 +224,10 @@ msgstr "Updated"
 
 #: src/components/cookies-banner.tsx:47
 msgid "We use cookies on this website"
+msgstr ""
+
+#: src/components/header.tsx:18
+msgid "What We Do"
 msgstr ""
 
 #: src/components/learning-center/article-template.tsx:110

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -35,24 +35,24 @@ msgid "Assert your tenant rights by using our digital tools"
 msgstr ""
 
 #: src/components/learning-center/category-page-template.tsx:28
-msgid "Back to Overview"
-msgstr "Volver a la Vista General"
+#~ msgid "Back to Overview"
+#~ msgstr "Volver a la Vista General"
 
 #: src/components/cookies-banner.tsx:24
 msgid "By using our website you consent to the use of cookies."
 msgstr ""
 
-#: src/components/header.tsx:24
+#: src/components/header.tsx:25
 msgid "Careers"
 msgstr ""
 
 #: src/components/accordion.tsx:12
 #: src/components/cookies-banner.tsx:32
-#: src/components/header.tsx:86
+#: src/components/header.tsx:119
 msgid "Close"
 msgstr ""
 
-#: src/components/header.tsx:25
+#: src/components/header.tsx:26
 msgid "Contact Us"
 msgstr "Contáctanos"
 
@@ -60,7 +60,7 @@ msgstr "Contáctanos"
 msgid "Contents"
 msgstr ""
 
-#: src/components/header.tsx:69
+#: src/components/header.tsx:102
 msgid "DEMO SITE"
 msgstr "SITIO DEMO"
 
@@ -92,19 +92,20 @@ msgstr "¡Únete a nuestra lista de correo!"
 msgid "Learn more"
 msgstr ""
 
-#: src/components/header.tsx:23
+#: src/components/header.tsx:24
 #: src/components/learning-center/article-template.tsx:74
+#: src/components/learning-center/category-page-template.tsx:14
 #: src/pages/learn.en.tsx:90
 msgid "Learning Center"
 msgstr ""
 
-#: src/components/header.tsx:86
+#: src/components/header.tsx:119
 msgid "Menu"
 msgstr ""
 
 #: src/components/header.tsx:17
-msgid "Mission"
-msgstr "Misión"
+#~ msgid "Mission"
+#~ msgstr "Misión"
 
 #: src/components/learning-center/learning-searchbar.tsx:73
 msgid "No articles match your search."
@@ -127,7 +128,7 @@ msgstr "¡Vaya! Hubo un error en la red. Inténtalo más tarde."
 msgid "Oops! That email is invalid."
 msgstr "¡Vaya! Ese correo electrónico no es válido."
 
-#: src/components/header.tsx:19
+#: src/components/header.tsx:20
 msgid "Partners & Funders"
 msgstr ""
 
@@ -139,7 +140,7 @@ msgstr ""
 msgid "Please enter an email address!"
 msgstr "Por favor, ¡introduzca una dirección de correo electrónico!"
 
-#: src/components/header.tsx:20
+#: src/components/header.tsx:21
 msgid "Press"
 msgstr "Prensa"
 
@@ -157,7 +158,7 @@ msgstr ""
 msgid "Read More"
 msgstr "Lee más"
 
-#: src/components/header.tsx:22
+#: src/components/header.tsx:23
 msgid "Research & Policy"
 msgstr ""
 
@@ -169,7 +170,8 @@ msgstr ""
 msgid "See all articles"
 msgstr ""
 
-#: src/components/header.tsx:78
+#: src/components/header.tsx:111
+#: src/components/layout.tsx:100
 msgid "See our tools"
 msgstr ""
 
@@ -190,11 +192,11 @@ msgstr ""
 msgid "Take action"
 msgstr ""
 
-#: src/components/header.tsx:18
+#: src/components/header.tsx:19
 msgid "Team"
 msgstr "Equipo"
 
-#: src/components/header.tsx:73
+#: src/components/header.tsx:106
 msgid "Technology for Housing Justice"
 msgstr ""
 
@@ -214,7 +216,7 @@ msgstr ""
 msgid "This means that we’re able to see your approximate location, the type of device you’re using, and your operating system."
 msgstr ""
 
-#: src/components/header.tsx:21
+#: src/components/header.tsx:22
 msgid "Tools"
 msgstr ""
 
@@ -227,6 +229,10 @@ msgstr "Actualizado"
 
 #: src/components/cookies-banner.tsx:47
 msgid "We use cookies on this website"
+msgstr ""
+
+#: src/components/header.tsx:18
+msgid "What We Do"
 msgstr ""
 
 #: src/components/learning-center/article-template.tsx:110

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -20,12 +20,12 @@
   width: 100%;
   background-color: $white;
   font-size: 2.25rem;
+  z-index: 100;
 
   @include mobile {
     &.jf-sticky {
       position: fixed;
       top: 0;
-      z-index: 10;
     }
   }
 


### PR DESCRIPTION
This PR implements a collection of minor QA fixes related to the navbar menu.

* [sc-10297] - [navbar menu cover all elements (tools button)](https://github.com/JustFixNYC/justfix-website/commit/8dc01e6e7e0f5bc8aa879c87ae3fa2e6d0b2aa57) 
* [sc-10303] - [update mission and careers links in navbar menu](https://github.com/JustFixNYC/justfix-website/commit/63f0198553861027f1a0112fc14f35f4b8237506)
* [sc-10299] - [move language toogle up in navbar menu](https://github.com/JustFixNYC/justfix-website/commit/a82d81498e215c9b2b9d8b368410bdad4b12184c)
* [sc-10301] - [increase clickable area for navbar menu links](https://github.com/JustFixNYC/justfix-website/commit/8085a05f1eb9c26144bbaa483492ed20b58b39f5)
<img width="431" alt="image" src="https://user-images.githubusercontent.com/16906516/181368658-66a4b261-6222-459e-b406-ef21a5129ab8.png">