### PR TITLE
Reports page QA - cut tweets, fix image border radius on mobile

### DIFF
--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -40,10 +40,8 @@ const ReportCard: React.FC<ReportCardInfo> = (props) => (
     <div className="jf-report-card columns is-paddingless is-multiline has-background-white">
       <div className="column is-6 is-paddingless">
         <Img
-          fluid={props.image.fluid}
+          fluid={{ ...props.image.fluid, aspectRatio: 1 }}
           alt=""
-          objectFit="cover"
-          objectPosition="100% 0%"
           className="jf-report-img"
         />
       </div>

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -22,38 +22,6 @@ function formatDate(dateString: string, locale?: string): string {
   });
 }
 
-type EndorsementInfo = {
-  userName: string;
-  userImage: {
-    fluid: any;
-  };
-  userLink: string;
-  message: {
-    json: any;
-  };
-  messageLink: string;
-};
-
-const Endorsement: React.FC<EndorsementInfo> = (props) => (
-  <div className="mt-8 mt-6-mobile pb-5 pb-0-mobile">
-    <div className="is-flex has-text-centered is-align-items-center">
-      <figure className="image is-48x48">
-        <Img
-          fluid={props.userImage.fluid}
-          alt=""
-          className="is-rounded img-centered"
-        />
-      </figure>
-      <span className="is-small is-bold pl-5">
-        {props.userName} <Trans>says:</Trans>
-      </span>
-    </div>
-    <div className="title is-4 pl-10 pl-0-mobile pt-5-mobile">
-      {documentToReactComponents(props.message.json)}
-    </div>
-  </div>
-);
-
 type ReportCardInfo = {
   reportTitle: string;
   publicationDate: string;
@@ -64,14 +32,11 @@ type ReportCardInfo = {
   image: {
     fluid: any;
   };
-  endorsements: EndorsementInfo[];
   locale: string;
-  hasDivider: boolean;
 };
 
 const ReportCard: React.FC<ReportCardInfo> = (props) => (
-  <div className={`${!props.hasDivider ? "mt-6" : ""} mt-0-mobile`}>
-    {props.hasDivider && <div className="is-divider" />}
+  <div className="mt-6 mb-9 mt-0-mobile">
     <div className="jf-report-card columns is-paddingless is-multiline has-background-white">
       <div className="column is-6 is-paddingless">
         <Img
@@ -143,12 +108,7 @@ export const PolicyPageScaffolding = (props: ContentfulContent) => {
           </div>
           <div className="column is-9 pb-9 py-0-mobile">
             {props.content.reportBlocks.map((report: any, i: number) => (
-              <div key={i}>
-                <ReportCard {...report} locale={locale} hasDivider={i > 0} />
-                {report.endorsements.map((endorsement: any, i: number) => (
-                  <Endorsement {...endorsement} key={i} />
-                ))}
-              </div>
+              <ReportCard {...report} locale={locale} key={i} />
             ))}
           </div>
         </div>
@@ -193,19 +153,6 @@ export const PolicyPageFragment = graphql`
           fluid {
             ...GatsbyContentfulFluid
           }
-        }
-        endorsements {
-          userName
-          userImage {
-            fluid {
-              ...GatsbyContentfulFluid
-            }
-          }
-          userLink
-          message {
-            json
-          }
-          messageLink
         }
       }
     }

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -1,5 +1,4 @@
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
-import { Trans } from "@lingui/macro";
 import { graphql, StaticQuery } from "gatsby";
 import React from "react";
 import Layout from "../components/layout";

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -39,7 +39,9 @@ const ReportCard: React.FC<ReportCardInfo> = (props) => (
     <div className="jf-report-card columns is-paddingless is-multiline has-background-white">
       <div className="column is-6 is-paddingless">
         <Img
-          fluid={{ ...props.image.fluid, aspectRatio: 1 }}
+          fluid={props.image.fluid}
+          objectFit="cover"
+          objectPosition="100% 0%"
           alt=""
           className="jf-report-img"
         />

--- a/src/styles/reports.scss
+++ b/src/styles/reports.scss
@@ -12,6 +12,7 @@
         height: 100%;
 
         @include mobile {
+          border-radius: 0.25rem 0.25rem 0 0; // 4px
           height: 15rem; // 240px
         }
       }


### PR DESCRIPTION
[sc-10382] - [remove endorsement tweets and divider](https://github.com/JustFixNYC/justfix-website/commit/063336382263ce8525076719f292018922f9dcfc)

<img width="1460" alt="image" src="https://user-images.githubusercontent.com/16906516/181377868-47a7e7db-cc6a-479b-bad6-8da68bc039ad.png">
<img width="420" alt="image" src="https://user-images.githubusercontent.com/16906516/181377905-de02a5b0-da2d-43d2-b2f4-879be31842c3.png">

While I was here, I noticed the rounded corners of the report images needed to be rotated for mobile