### PR TITLE
Home page QA: partners & research section spacing and mobile headers

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -13,6 +13,7 @@ import { LocaleLink as Link } from "../components/locale-link";
 import { ReadMoreLink } from "../components/read-more";
 import classnames from "classnames";
 import classNames from "classnames";
+import ResponsiveElement from "../components/responsive-element";
 
 const PRODUCT_CTA_UTM_CODE = "?utm_source=orgsite&utm_medium=productcta";
 
@@ -259,9 +260,9 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
           <div className="column is-6 is-12-mobile is-flex is-flex-direction-column">
             <h1 className="mb-6">{props.content.partnershipsSectionTitle}</h1>
             <div className="has-background-success p-8 pt-11 is-flex-grow-1 is-flex is-flex-direction-column">
-              <h2 className="mb-11">
+              <ResponsiveElement desktop="h2" touch="h3" className="mb-11">
                 {props.content.partnershipsSectionSubtitle}
-              </h2>
+              </ResponsiveElement>
               <Link
                 to={props.content.partnershipsSectionButton.link}
                 className="button is-primary mt-auto is-align-self-flex-start"
@@ -273,7 +274,9 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
           <div className="column is-6 is-12-mobile is-flex is-flex-direction-column">
             <h1 className="mb-6">{props.content.policySectionTitle}</h1>
             <div className="has-background-link p-8 pt-11 is-flex-grow-1 is-flex is-flex-direction-column">
-              <h2 className="mb-11">{props.content.policySectionSubtitle}</h2>
+              <ResponsiveElement desktop="h2" touch="h3" className="mb-11">
+                {props.content.policySectionSubtitle}
+              </ResponsiveElement>
               <Link
                 to={props.content.policySectionButton.link}
                 className="button is-primary mt-auto is-align-self-flex-start"

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -174,9 +174,9 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
 
       <ProductList {...props.content} />
 
-      <div className="jf-learning-center-preview mb-12">
+      <div className="jf-learning-center-preview mb-12 mb-0-mobile">
         <div className="columns">
-          <div className="column is-12 pt-10 pt-7-mobile pb-9">
+          <div className="column is-12 pt-10 pt-7-mobile pb-9 pb-5-mobile">
             <h1 className="is-hidden-touch">
               {props.content.learningCenterPreviewTitle}
             </h1>
@@ -254,7 +254,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
         </div>
       </div>
 
-      <div className="mb-12">
+      <div className="mb-12 mb-9-mobile">
         <div className="columns">
           <div className="column is-6 is-12-mobile is-flex is-flex-direction-column">
             <h1 className="mb-6">{props.content.partnershipsSectionTitle}</h1>


### PR DESCRIPTION
[sc-10325 ] - [reduce section vertical spacing on mobile](https://github.com/JustFixNYC/justfix-website/commit/3835fb6bdb89a4c925b61ceb8321b2e7a1d4af36)

<img width="434" alt="image" src="https://user-images.githubusercontent.com/16906516/181562326-5ac135dc-eb9a-4a2c-a803-085cb35c5910.png">
<img width="434" alt="image" src="https://user-images.githubusercontent.com/16906516/181562898-4b665660-bced-409b-9948-f9fd78bfa5bc.png">

[sc-10327] - [partners & research titles use h3 on mobile](https://github.com/JustFixNYC/justfix-website/pull/246/commits/1af4f5d0c9bfc2f3c5faae7025e8dc25116f650e)

<img width="435" alt="image" src="https://user-images.githubusercontent.com/16906516/181586955-5134e6aa-bed7-4ef3-939d-7b2fc7dc8d6a.png">



