### PR TITLE
Home page QA: use h1 for all sections on homepage

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -112,9 +112,7 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
   >
     <div className="columns is-multiline">
       <div className="column is-12 pt-10 pt-7-mobile pb-9">
-        <h1 className="is-hidden-touch">{props.productSectionTitle}</h1>
-        <h2 className="is-hidden-desktop">{props.productSectionTitle}</h2>
-        <h3 className="mt-2">{props.productSectionSubtitle}</h3>
+        <h1>{props.productSectionTitle}</h1>
       </div>
       {shuffleArray(props.homePageProductBlocks).map(
         (product: any, i: number) => (
@@ -175,12 +173,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
       <div className="jf-learning-center-preview mb-12">
         <div className="columns">
           <div className="column is-12 pt-10 pt-7-mobile pb-9">
-            <h1 className="is-hidden-touch">
-              {props.content.learningCenterPreviewTitle}
-            </h1>
-            <h2 className="is-hidden-desktop">
-              {props.content.learningCenterPreviewTitle}
-            </h2>
+            <h1>{props.content.learningCenterPreviewTitle}</h1>
             <h3 className="mt-2">
               {props.content.learningCenterPreviewSubtitle}
             </h3>
@@ -314,7 +307,6 @@ export const LandingPageFragment = graphql`
         link
       }
       productSectionTitle
-      productSectionSubtitle
       homePageProductBlocks {
         productName
         title


### PR DESCRIPTION
[sc-10338]
This PR updates section titles to all be H1 on Home page, previous "Discover Our Tools" and "Learning Center" departed from the other styles. Also removes the tools subtitle section (home and tools page)

<img width="442" alt="image" src="https://user-images.githubusercontent.com/16906516/181600037-95e85ce8-3b3b-41e4-bfa7-ac98fdaa9575.png">

This also applies on the Tools page
<img width="449" alt="image" src="https://user-images.githubusercontent.com/16906516/181600171-d032fdc9-dab5-409d-a83f-5a459742c498.png">

<img width="446" alt="image" src="https://user-images.githubusercontent.com/16906516/181600079-3135dd91-eacb-47e5-9aab-d59e5be04e53.png">
