### PR TITLE
make all article headlines clickable

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -184,9 +184,14 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                   <div className="eyebrow is-large mb-6">
                     <Trans>Featured article</Trans>
                   </div>
-                  <h2 className="mb-6">
-                    {props.content.learningCenterPreviewArticles[0].title}
-                  </h2>
+                  <Link
+                    to={`/learn/${props.content.learningCenterPreviewArticles[0].slug}`}
+                    className="no-underline"
+                  >
+                    <h2 className="mb-6">
+                      {props.content.learningCenterPreviewArticles[0].title}
+                    </h2>
+                  </Link>
                   <div className="eyebrow is-large mb-5">
                     <Trans>Updated</Trans>{" "}
                     {props.content.learningCenterPreviewArticles[0].dateUpdated}
@@ -204,9 +209,14 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                 <div className="column is-marginless is-paddingless is-7 is-12-touch">
                   <div className="columns is-marginless is-paddingless is-multiline">
                     <div className="column is-marginless is-12 py-6 px-9">
-                      <h3 className="mb-4">
-                        {props.content.learningCenterPreviewArticles[1].title}
-                      </h3>
+                      <Link
+                        to={`/learn/${props.content.learningCenterPreviewArticles[1].slug}`}
+                        className="no-underline"
+                      >
+                        <h3 className="mb-4">
+                          {props.content.learningCenterPreviewArticles[1].title}
+                        </h3>
+                      </Link>
                       <div className="eyebrow is-large mb-4">
                         <Trans>Updated</Trans>{" "}
                         {
@@ -219,9 +229,14 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                       />
                     </div>
                     <div className="column is-marginless is-12 py-6 px-9">
-                      <h3 className="mb-4">
-                        {props.content.learningCenterPreviewArticles[2].title}
-                      </h3>
+                      <Link
+                        to={`/learn/${props.content.learningCenterPreviewArticles[2].slug}`}
+                        className="no-underline"
+                      >
+                        <h3 className="mb-4">
+                          {props.content.learningCenterPreviewArticles[2].title}
+                        </h3>
+                      </Link>
                       <div className="eyebrow is-large mb-4">
                         <Trans>Updated</Trans>{" "}
                         {

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -121,7 +121,9 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
             )}
           </div>
           <div className="mb-6 mb-3-mobile">
-            <h3 className="mb-6 mb-3-mobile">{props.title}</h3>
+            <LocaleLink className={"no-underline"} to={articleUrl}>
+              <h3 className="mb-6 mb-3-mobile">{props.title}</h3>
+            </LocaleLink>
             <span className="is-hidden-mobile eyebrow is-small">
               <Trans>Updated</Trans> {formatDate(props.dateUpdated, locale)}
             </span>

--- a/src/pages/press.en.tsx
+++ b/src/pages/press.en.tsx
@@ -62,9 +62,11 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
                   </figure>
                   <div className="jf-press-title title is-3">{press.title}</div>
                 </div>
-                <ResponsiveElement desktop="h2" touch="h3" className="mb-6">
-                  {press.linkText}
-                </ResponsiveElement>
+                <OutboundLink href={press.hyperlink} className="no-underline">
+                  <ResponsiveElement desktop="h2" touch="h3" className="mb-6">
+                    {press.linkText}
+                  </ResponsiveElement>
+                </OutboundLink>
                 {!press.isFeaturedArticle && (
                   <div className="eyebrow is-large mb-6">
                     {formatDate(press.publicationDate, locale)}


### PR DESCRIPTION
This PR makes all the following titles clickable:
- Article titles in the Learning Center module on homepage.
- Article titles on the Press page
- Article titles on the Learning center homepage.

[sc-10319]