### PR TITLE
Add wide desktop breakpoint, page styles

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -122,24 +122,26 @@ const LayoutScaffolding = ({
         <meta name="twitter:image" content={shareImageURL} />
         <meta name="twitter:image:alt" content={title} />
       </Helmet>
-      <Header isLandingPage={isLandingPage} />
-      <div
-        className={
-          // Add extra space at bottom of page for fixed footer button:
-          classnames(isHomepage && "mb-12-mobile")
-        }
-      >
-        {children}
-        <Footer />
-        <div className="jf-footer-menu">
-          <CookiesBanner />
-          {isHomepage && (
-            <div className="has-background-black py-5 is-flex is-justify-content-center is-hidden-desktop">
-              <LocaleLink to="/tools" className="button is-primary">
-                <Trans>See our tools</Trans>
-              </LocaleLink>
-            </div>
-          )}
+      <div className="jf-page-body">
+        <Header isLandingPage={isLandingPage} />
+        <div
+          className={
+            // Add extra space at bottom of page for fixed footer button:
+            classnames(isHomepage && "mb-12-mobile")
+          }
+        >
+          {children}
+          <Footer />
+          <div className="jf-footer-menu">
+            <CookiesBanner />
+            {isHomepage && (
+              <div className="has-background-black py-5 is-flex is-justify-content-center is-hidden-desktop">
+                <LocaleLink to="/tools" className="button is-primary">
+                  <Trans>See our tools</Trans>
+                </LocaleLink>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </I18nProvider>

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -15,6 +15,12 @@
   }
 }
 
+@mixin wide-desktop {
+  @media screen and (min-width: $wide-desktop) {
+    @content;
+  }
+}
+
 // FONTS:
 
 @font-face {
@@ -452,5 +458,19 @@ $column-gap: 18px;
   @include mobile {
     padding-left: calc(#{$spacing-06} - #{$column-gap});
     padding-right: calc(#{$spacing-06} - #{$column-gap});
+  }
+}
+
+// WIDE DESKTOP STYLES:
+
+@include wide-desktop {
+  body {
+    background-color: $justfix-white;
+  }
+
+  .jf-page-body {
+    max-width: $wide-desktop;
+    margin: auto;
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
   }
 }

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -1,5 +1,9 @@
 @import "../../node_modules/bulma/sass/utilities/functions.sass";
 
+// MEDIA:
+
+$wide-desktop: 1515px;
+
 // COLORS:
 
 $justfix-black: #242323;


### PR DESCRIPTION
[sc-10446]

per discussion with tahnee, new styles for an extremely wide desktop view! adds a new wrapper div around the entire page which is potentially a little dangerous as it changes the dom structure of everything, but i tested a few pages & skimmed the CSS and it doesn't seem like this should break anything

<img width="953" alt="Screen Shot 2022-07-28 at 12 25 28 PM" src="https://user-images.githubusercontent.com/34112083/181620957-e68aabc3-8363-4a11-b676-1617b546f308.png">
