### PR TITLE
Article headline link underline on hover

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -186,7 +186,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                   </div>
                   <Link
                     to={`/learn/${props.content.learningCenterPreviewArticles[0].slug}`}
-                    className="no-underline"
+                    className="jf-link-article"
                   >
                     <h2 className="mb-6">
                       {props.content.learningCenterPreviewArticles[0].title}
@@ -211,7 +211,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                     <div className="column is-marginless is-12 py-6 px-9">
                       <Link
                         to={`/learn/${props.content.learningCenterPreviewArticles[1].slug}`}
-                        className="no-underline"
+                        className="jf-link-article"
                       >
                         <h3 className="mb-4">
                           {props.content.learningCenterPreviewArticles[1].title}
@@ -231,7 +231,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                     <div className="column is-marginless is-12 py-6 px-9">
                       <Link
                         to={`/learn/${props.content.learningCenterPreviewArticles[2].slug}`}
-                        className="no-underline"
+                        className="jf-link-article"
                       >
                         <h3 className="mb-4">
                           {props.content.learningCenterPreviewArticles[2].title}

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -121,7 +121,7 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
             )}
           </div>
           <div className="mb-6 mb-3-mobile">
-            <LocaleLink className={"no-underline"} to={articleUrl}>
+            <LocaleLink className={"jf-link-article"} to={articleUrl}>
               <h3 className="mb-6 mb-3-mobile">{props.title}</h3>
             </LocaleLink>
             <span className="is-hidden-mobile eyebrow is-small">

--- a/src/pages/press.en.tsx
+++ b/src/pages/press.en.tsx
@@ -62,7 +62,10 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
                   </figure>
                   <div className="jf-press-title title is-3">{press.title}</div>
                 </div>
-                <OutboundLink href={press.hyperlink} className="no-underline">
+                <OutboundLink
+                  href={press.hyperlink}
+                  className="jf-link-article"
+                >
                   <ResponsiveElement desktop="h2" touch="h3" className="mb-6">
                     {press.linkText}
                   </ResponsiveElement>

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -241,6 +241,16 @@ div.is-rounded img {
   filter: invert(1) contrast(1.3);
 }
 
+.jf-link-article {
+  text-decoration: none;
+
+  &:hover,
+  &:focus,
+  &:active {
+    text-decoration: underline;
+  }
+}
+
 .jf-email-form {
   max-width: 400px;
   .button {


### PR DESCRIPTION
Headlines for articles that are link show underline on hover/active/focus

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/16906516/181636407-4e925632-798e-43d6-8765-07367cd6f25e.png">
<img width="1210" alt="image" src="https://user-images.githubusercontent.com/16906516/181636466-69d80f2a-1628-4f4e-9669-e70fb08c3fb9.png">

[sc-10319]