### PR TITLE
Don't stretch and crop partner logos

### DIFF
--- a/src/pages/partners.en.tsx
+++ b/src/pages/partners.en.tsx
@@ -58,6 +58,7 @@ const PartnerCard: React.FC<PartnerDetails> = ({ name, link, logo }) => (
           width: "150px",
           height: "150px",
         }}
+        objectFit="contain"
       />
       <OutboundLink className="mb-9 mx-2" href={link}>
         {formatLinkLabel(link)}
@@ -88,6 +89,7 @@ const PartnerCardMobile: React.FC<PartnerDetails> = ({ name, link, logo }) => (
             width: "150px",
             height: "150px",
           }}
+          objectFit="contain"
         />
         <OutboundLink className="mb-9 mx-2" href={link}>
           {formatLinkLabel(link)}


### PR DESCRIPTION
[sc-10467]

change the object fit so that the entire logo is visible:
<img width="942" alt="Screen Shot 2022-07-28 at 3 50 57 PM" src="https://user-images.githubusercontent.com/34112083/181650212-c0bdd134-5d5a-40cc-a37a-94f7bf321cea.png">

