### PR TITLE
Center language toggle text

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -17,7 +17,7 @@ export const FooterLanguageToggle = () => {
       <LocaleToggle
         to="en"
         className={classnames(
-          "button eyebrow is-small",
+          "button eyebrow is-small is-justify-content-center",
           locale === "en" && "is-selected"
         )}
       >
@@ -26,7 +26,7 @@ export const FooterLanguageToggle = () => {
       <LocaleToggle
         to="es"
         className={classnames(
-          "button eyebrow is-small",
+          "button eyebrow is-small is-justify-content-center",
           locale === "es" && "is-selected"
         )}
       >


### PR DESCRIPTION
[sc-10225]

For some reason these were being made flex only in the header but not footer and bulma threw off alignment. 

before
<img width="296" alt="image" src="https://user-images.githubusercontent.com/16906516/181766946-6fd29fff-c86d-4679-a0a9-699a42f9ae13.png">

after
<img width="318" alt="image" src="https://user-images.githubusercontent.com/16906516/181766748-dbde2652-067a-4261-a415-aabd2f7d6643.png">
