### PR TITLE
homepage learning center preview body text 

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -196,15 +196,15 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                     <Trans>Updated</Trans>{" "}
                     {props.content.learningCenterPreviewArticles[0].dateUpdated}
                   </div>
-                  <p>
+                  <p className="title is-4">
                     {
                       props.content.learningCenterPreviewArticles[0].metadata
                         .description
-                    }{" "}
-                    <ReadMoreLink
-                      url={`/learn/${props.content.learningCenterPreviewArticles[0].slug}`}
-                    />
+                    }
                   </p>
+                  <ReadMoreLink
+                    url={`/learn/${props.content.learningCenterPreviewArticles[0].slug}`}
+                  />
                 </div>
                 <div className="column is-marginless is-paddingless is-7 is-12-touch">
                   <div className="columns is-marginless is-paddingless is-multiline">


### PR DESCRIPTION
[sc-10253]

Homepage: increase body copy size for Learning Center, and move down the read more link

before
<img width="557" alt="image" src="https://user-images.githubusercontent.com/16906516/181772322-b358a30c-3e4f-4265-bd1f-aefc6daf7caf.png">

after
<img width="566" alt="image" src="https://user-images.githubusercontent.com/16906516/181772147-5393167e-19ca-40a2-a58f-b5aedfbcc64b.png">
