### PR TITLE
fix eng-only flag for featured article

### DIFF
--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -131,23 +131,30 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
             </span>
             <h4 className="my-6 my-3-mobile">{props.metadata.description}</h4>
           </div>
-          {isFeatured ? (
-            <div className="jf-article-link-container is-flex">
-              <LocaleLink
-                className={"button is-primary mt-0 mt-4-mobile"}
-                to={articleUrl}
+          <div className="is-flex">
+            {isFeatured ? (
+              <div className="jf-article-link-container is-flex is-flex-direction-row">
+                <LocaleLink
+                  className={"button is-primary mt-0 mt-4-mobile"}
+                  to={articleUrl}
+                >
+                  <Trans>Read More</Trans>
+                </LocaleLink>
+              </div>
+            ) : (
+              <ReadMoreLink url={articleUrl} />
+            )}
+            {locale === "es" && props.englishOnly && (
+              <span
+                className={classnames(
+                  "has-text-danger is-italic px-3",
+                  isFeatured && "is-align-self-center pl-4"
+                )}
               >
-                <Trans>Read More</Trans>
-              </LocaleLink>
-            </div>
-          ) : (
-            <ReadMoreLink url={articleUrl} />
-          )}
-          {locale === "es" && props.englishOnly && (
-            <span className="has-text-danger is-italic px-3">
-              Solo en inglés
-            </span>
-          )}
+                Solo en inglés
+              </span>
+            )}
+          </div>
           {!isFeatured && !props.isLast && (
             <div className="is-divider mt-24 mb-0"></div>
           )}


### PR DESCRIPTION
The styling of the "english only" flag on LC articles was off when it's a featured article. This PR does a quick fix, but this is something to revisit in general for style and color of these flags.

<img width="480" alt="image" src="https://user-images.githubusercontent.com/16906516/181817065-d1e6cce4-92c0-478f-a493-2ae7694629f3.png">
<img width="425" alt="image" src="https://user-images.githubusercontent.com/16906516/181817103-8fce955b-99ce-4834-a1ec-bda045606242.png">

<img width="382" alt="image" src="https://user-images.githubusercontent.com/16906516/181817041-1df9bdca-3117-44ee-b83a-d6880e1f89f2.png">
