### PR TITLE
Remove deprecated Contentful fields from graphql queries

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -84,14 +84,8 @@ const generateLearningPages = async function ({ actions, graphql }, locale) {
           __typename
           ... on ContentfulLearningArticleCtaBlock {
             title
-            subtitle
             ctaText
             ctaLink
-            secondaryCta {
-              subtitle
-              ctaText
-              ctaLink
-            }
           }
           ... on ContentfulLearningArticleSection {
             title


### PR DESCRIPTION
Simple change to our graphql query for LC page generation, removing old fields that we no longer use and that have been deleted from our content models on Contentful.