### PR TITLE
Make buttons inline-block for Safari sizing

### DIFF
--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -317,8 +317,7 @@ $body-color: $justfix-black;
   padding: $spacing-06 $spacing-07;
 
   height: fit-content;
-  // IE support:
-  display: table;
+  display: inline-block;
   flex: none;
   box-shadow: 0.25rem 0.25rem 0rem $justfix-grey-light;
   max-width: 100%;


### PR DESCRIPTION
[sc-10284] Will affect all the buttons across the orgsite, I clicked through the pages and everything seemed solid (mobile/desktop). This fix is specifically for safari, where `display: table` causes weird sizing issues