### PR TITLE
fix cookies banner width for widescreen

### DIFF
--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -335,6 +335,10 @@ a.has-text-black:hover {
 .jf-cookies-banner {
   border-top: 1px solid $justfix-black;
 
+  @include wide-desktop {
+    width: $wide-desktop;
+  }
+
   img {
     filter: invert(1) contrast(0.7);
   }


### PR DESCRIPTION
[sc-10491]

This PR fixes an issue where fixed position cookies banner extended past the designated page width on widescreen.

<img width="1558" alt="image" src="https://user-images.githubusercontent.com/16906516/182202721-30af6831-beef-48bf-b95b-8bc23d6808ab.png">