### PR TITLE
Homepage learning center preview QA

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -180,7 +180,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
             </h3>
             <div className="has-background-warning mt-9">
               <div className="columns is-desktop is-marginless is-paddingless">
-                <div className="column is-marginless is-5 is-12-touch p-9">
+                <div className="column jf-lc-featured is-marginless is-6 is-12-touch p-9">
                   <div className="eyebrow is-large mb-6">
                     <Trans>Featured article</Trans>
                   </div>
@@ -206,7 +206,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                     url={`/learn/${props.content.learningCenterPreviewArticles[0].slug}`}
                   />
                 </div>
-                <div className="column is-marginless is-paddingless is-7 is-12-touch">
+                <div className="column is-marginless is-paddingless is-6 is-12-touch">
                   <div className="columns is-marginless is-paddingless is-multiline">
                     <div className="column is-marginless is-12 py-6 px-9">
                       <Link
@@ -248,7 +248,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                         url={`/learn/${props.content.learningCenterPreviewArticles[2].slug}`}
                       />
                     </div>
-                    <div className="column is-marginless is-12 py-6 px-9">
+                    <div className="column is-marginless is-12 py-8 px-9">
                       <Link to="/learn" className="button is-primary">
                         <Trans>See all articles</Trans>
                       </Link>

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -188,9 +188,9 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                     to={`/learn/${props.content.learningCenterPreviewArticles[0].slug}`}
                     className="jf-link-article"
                   >
-                    <h2 className="mb-6">
+                    <ResponsiveElement className="mb-6" desktop="h2" touch="h3">
                       {props.content.learningCenterPreviewArticles[0].title}
-                    </h2>
+                    </ResponsiveElement>
                   </Link>
                   <div className="eyebrow is-large mb-5">
                     <Trans>Updated</Trans>{" "}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -33,7 +33,7 @@
 
 .home-page {
   .jf-learning-center-preview {
-    .column.is-5 {
+    .jf-lc-featured {
       @include desktop {
         border-right: 1px solid $justfix-black;
       }
@@ -43,7 +43,7 @@
       }
     }
 
-    .column.is-7 .column:not(:last-child) {
+    .column.is-6 .column:not(:last-child) {
       border-bottom: 1px solid $justfix-black;
     }
   }


### PR DESCRIPTION
[sc-10293] - [change featured article title to H3 on mobile](https://github.com/JustFixNYC/justfix-website/commit/3f0297e9cbd73f5b429aff39a498850392ed1bd9)

<img width="430" alt="image" src="https://user-images.githubusercontent.com/16906516/182403251-ef31b4aa-6a58-47a5-86e4-1e5a9d4ae10f.png">

[sc-10251] - [featured and other each take half of container](https://github.com/JustFixNYC/justfix-website/commit/6674ff64507490f7b529c6df6691bad359f17645)

<img width="1259" alt="image" src="https://user-images.githubusercontent.com/16906516/182403323-e76a8b65-4b25-4f4b-a57e-d8365fe175c3.png">
