### PR TITLE
fix padding on LC article previews

### DIFF
--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -108,8 +108,8 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
         )}
         <div
           className={classnames(
-            "py-7 mb-2 px-0",
-            isFeatured ? "px-6" : "px-0",
+            "pt-7 mb-2",
+            isFeatured ? "pb-7 px-6" : "px-0",
             !isFeatured && !props.isLast ? "pb-0-mobile" : ""
           )}
         >
@@ -156,7 +156,7 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
             )}
           </div>
           {!isFeatured && !props.isLast && (
-            <div className="is-divider mt-24 mb-0"></div>
+            <div className="is-divider mt-8 mb-0"></div>
           )}
         </div>
       </div>


### PR DESCRIPTION
decrease padding above articles and increase padding below articles

[sc-10395]

<img width="981" alt="image" src="https://user-images.githubusercontent.com/16906516/182428853-6d5b23a6-a1f9-47fb-a9db-a3e691e157f6.png">
<img width="459" alt="image" src="https://user-images.githubusercontent.com/16906516/182428904-86aef3e9-0057-490c-9f88-4453af467a58.png">
