### PR TITLE
vision subtitle as separate field/style for mobile

### DIFF
--- a/src/pages/our-mission.en.tsx
+++ b/src/pages/our-mission.en.tsx
@@ -9,6 +9,8 @@ import { ReadMoreLink } from "../components/read-more";
 import { Accordion } from "../components/accordion";
 import ResponsiveElement from "../components/responsive-element";
 
+import "../styles/our-mission.scss";
+
 export const MissionPageScaffolding = (props: ContentfulContent) => {
   const { content } = props;
   const latestReport = content.impactReportButtons[0];
@@ -40,6 +42,9 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
         </div>
         <div className="column is-1 is-hidden-mobile" />
         <div className="column is-7 pt-13 pb-12 p-6-mobile jf-text-block-with-spacing">
+          <ResponsiveElement desktop="h3" touch="h2">
+            {props.content.visionSubtitle}
+          </ResponsiveElement>
           {documentToReactComponents(props.content.visionContent.json)}
         </div>
       </div>
@@ -142,6 +147,7 @@ export const MissionPageFragment = graphql`
         json
       }
       visionTitle
+      visionSubtitle
       visionContent {
         json
       }

--- a/src/styles/our-mission.scss
+++ b/src/styles/our-mission.scss
@@ -1,0 +1,9 @@
+@import "_design-system.scss";
+
+.jf-text-block-with-spacing {
+  p {
+    @include desktop {
+      @include desktop-h4;
+    }
+  }
+}


### PR DESCRIPTION
This PR splits the vision statement content from a single rich text element to add a separate subtitle, and then fixes the subtitle style on mobile.

[sc-10360]

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/16906516/182451938-0c60aa1d-8a78-4495-a89f-38c3cb6e0039.png">
<img width="375" alt="image" src="https://user-images.githubusercontent.com/16906516/182452095-80798c24-6755-48e2-83d5-32b2cfd188b6.png">

<img width="752" alt="image" src="https://user-images.githubusercontent.com/16906516/182452004-e8b4bd7d-2e9d-47b4-b3b7-510a33835b7d.png">
