### PR TITLE
use product name slug as element key

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -27,6 +27,17 @@ const shuffleArray = (array: any[]) =>
     .sort((a, b) => a.sort - b.sort)
     .map(({ value }) => value);
 
+// https://gist.github.com/codeguy/6684588?permalink_comment_id=3243980#gistcomment-3243980
+const slugify = (text: string): string => {
+  return text
+    .normalize("NFKD")
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w\-]+/g, "")
+    .replace(/\-\-+/g, "-");
+};
+
 type ProductCardInfo = {
   productName: string;
   title: string;
@@ -119,7 +130,7 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
       </div>
       {shuffleArray(props.homePageProductBlocks).map(
         (product: any, i: number) => (
-          <ProductCard {...product} key={i} />
+          <ProductCard {...product} key={slugify(product.productName)} />
         )
       )}
       <div className="column is-4 is-12-mobile">


### PR DESCRIPTION
On the tools and homepage we show a list of all our product cards, and shuffle the order they are displayed each time. We noticed that on the first render they all are correct, but on refresh all the text of the cards is updated but the url for the button is unchanged. We believe the issue is that react is not re-rendering the button fully in production because we are using the product list array index as the element key. This PR changes to use the product name slug as the key instead.

[sc-10501]

If this works, it fixes #273 