### PR TITLE
disable shuffle order of tools

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -21,6 +21,23 @@ export type ContentfulContent = {
   content: any;
 };
 
+// const shuffleArray = (array: any[]) =>
+//   array
+//     .map((value) => ({ value, sort: Math.random() }))
+//     .sort((a, b) => a.sort - b.sort)
+//     .map(({ value }) => value);
+
+// https://gist.github.com/codeguy/6684588?permalink_comment_id=3243980#gistcomment-3243980
+const slugify = (text: string): string => {
+  return text
+    .normalize("NFKD")
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w\-]+/g, "")
+    .replace(/\-\-+/g, "-");
+};
+
 type ProductCardInfo = {
   productName: string;
   title: string;
@@ -116,7 +133,7 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
         <h1>{props.productSectionTitle}</h1>
       </div>
       {props.homePageProductBlocks.map((product: any, i: number) => (
-        <ProductCard {...product} key={i} />
+        <ProductCard {...product} key={slugify(product.productName)} />
       ))}
       <div className="column is-4 is-12-mobile">
         <div className="jf-card has-background-black has-text-white p-8 p-6-mobile">

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -21,23 +21,6 @@ export type ContentfulContent = {
   content: any;
 };
 
-const shuffleArray = (array: any[]) =>
-  array
-    .map((value) => ({ value, sort: Math.random() }))
-    .sort((a, b) => a.sort - b.sort)
-    .map(({ value }) => value);
-
-// https://gist.github.com/codeguy/6684588?permalink_comment_id=3243980#gistcomment-3243980
-const slugify = (text: string): string => {
-  return text
-    .normalize("NFKD")
-    .toLowerCase()
-    .trim()
-    .replace(/\s+/g, "-")
-    .replace(/[^\w\-]+/g, "")
-    .replace(/\-\-+/g, "-");
-};
-
 type ProductCardInfo = {
   productName: string;
   title: string;
@@ -128,11 +111,9 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
       <div className="column is-12 pt-10 pt-7-mobile pb-9">
         <h1>{props.productSectionTitle}</h1>
       </div>
-      {shuffleArray(props.homePageProductBlocks).map(
-        (product: any, i: number) => (
-          <ProductCard {...product} key={slugify(product.productName)} />
-        )
-      )}
+      {props.homePageProductBlocks.map((product: any, i: number) => (
+        <ProductCard {...product} key={i} />
+      ))}
       <div className="column is-4 is-12-mobile">
         <div className="jf-card has-background-black has-text-white p-8 p-6-mobile">
           <div className="mb-6 mb-9-mobile">


### PR DESCRIPTION
We are continuing to have a problem with the link not being updated in product cards when the order is shuffled #289 , so for now we are temporarily disabling that in production until we can fix it.