### PR TITLE
add tool name slug as key for outboundlink

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -95,7 +95,11 @@ export const ProductCard: React.FC<ProductCardInfo> = (props) => {
               ])}
           </div>
 
-          <OutboundLink href={toolLink} className="button is-primary">
+          <OutboundLink
+            href={toolLink}
+            className="button is-primary"
+            key={slugify(props.productName)}
+          >
             {props.button.title}
           </OutboundLink>
         </div>


### PR DESCRIPTION
Following up on #289 to also use the tool name slug as the key on the product card's child component button link