### PR TITLE
make "learn more" buttons inline on desktop

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -172,11 +172,12 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
       <div className="has-background-black has-text-white">
         <div className="columns">
           <div className="column is-12 pt-9 py-8-mobile">
-            <h1>{props.content.whoWeAreSection}</h1>
-            <br />
+            <h1 className="is-inline-desktop">
+              {props.content.whoWeAreSection}
+            </h1>
             <Link
               to={props.content.whoWeAreButton.link}
-              className="button is-primary mt-5 mb-10 mb-7-mobile"
+              className="button is-primary is-inline-block-desktop mt-5 mb-10 mb-7-mobile ml-5 ml-0-mobile"
             >
               {props.content.whoWeAreButton.title}
             </Link>
@@ -311,11 +312,12 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
 
       <div className="columns has-background-info">
         <div className="column is-12 pt-9 pt-6-mobile pb-12 pb-9-mobile">
-          <h1>{props.content.outroSectionTitle}</h1>
-          <br />
+          <h1 className="is-inline-desktop">
+            {props.content.outroSectionTitle}
+          </h1>
           <Link
             to={props.content.outroSectionButton.link}
-            className="button is-primary mt-5"
+            className="button is-primary mt-5 ml-5 ml-0-mobile"
           >
             {props.content.outroSectionButton.title}
           </Link>

--- a/src/pages/tools.en.tsx
+++ b/src/pages/tools.en.tsx
@@ -63,11 +63,12 @@ export const ToolsPageScaffolding = (props: ContentfulContent) => {
 
       <div className="columns has-background-success">
         <div className="column is-12 pt-9 pt-6-mobile pb-12 pb-9-mobile">
-          <h1>{props.content.outroSectionTitle}</h1>
-          <br />
+          <h1 className="is-inline-desktop">
+            {props.content.outroSectionTitle}
+          </h1>
           <Link
             to={props.content.outroSectionButton.link}
-            className="button is-primary mt-5"
+            className="button is-primary mt-5 ml-5 ml-0-mobile"
           >
             {props.content.outroSectionButton.title}
           </Link>


### PR DESCRIPTION
This PR makes "learn more" buttons inline when on desktop for some section on home and tools pages.

<img width="1309" alt="image" src="https://user-images.githubusercontent.com/16906516/182679475-bc2dcea2-74ff-47b5-9226-a1249ad70dc4.png">

[sc-10322]