### PR TITLE
increase mobile navbar hieght, center border

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -183,7 +183,7 @@ const Header: React.FC<{
                 <Trans>Technology for Housing Justice</Trans>
               </div>
               <div
-                className="navbar-item is-paddingless is-flex-grow-1"
+                className="navbar-item is-paddingless is-flex-grow-1 is-hidden-touch"
                 onClick={() => setBurgerMenuStatus(false)}
               />
               <div
@@ -195,7 +195,10 @@ const Header: React.FC<{
                 </Link>
               </div>
               <div
-                className={"navbar-item " + (burgerMenuIsOpen && "is-active")}
+                className={classnames(
+                  "navbar-item is-justify-content-center",
+                  burgerMenuIsOpen && "is-active"
+                )}
               >
                 <button
                   role="button"

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -51,7 +51,7 @@ $spacing-13: 10rem; // 160px
 // NAVBAR STYLES:
 
 $navbar-height: 7rem;
-$navbar-height-mobile: 4.375rem;
+$navbar-height-mobile: 5rem;
 
 // Since we want our navbar to always show the hamburger menu, let's set
 // the navbar breakpoint to be impossibly high:

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -50,6 +50,10 @@
         padding: 2rem 1.75rem;
         transition: none;
 
+        @include mobile {
+          width: 50%;
+        }
+
         &.is-active {
           background-color: $black;
           color: $white;
@@ -57,7 +61,7 @@
 
         &:first-child {
           @include desktop {
-            border-right: 2px solid $black;
+            border-right: 1px solid $black;
           }
         }
 


### PR DESCRIPTION
This PR makes some style changes to the navbar:

- makes the vertical lines on desktop the same weight on desktop

before
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/16906516/182693548-1528648b-2e75-4d8e-a4c8-259f53d2dfdd.png">
after
<img width="1251" alt="image" src="https://user-images.githubusercontent.com/16906516/182693578-c7f54193-b332-465e-8922-5bbf8d01f7cc.png">

- makes the navbar taller and the vertical line centered on mobile

before
<img width="379" alt="image" src="https://user-images.githubusercontent.com/16906516/182693732-124593c9-0847-4d7f-8cf0-8e45e05ffc7e.png">

after
<img width="382" alt="image" src="https://user-images.githubusercontent.com/16906516/182693783-324b3f5c-38a4-4106-b2c4-a3c9d13d1211.png">


[sc-10526]
[sc-10526]