### PR TITLE
remove extra letter spacing for .navbar-item .link +

### DIFF
--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -122,8 +122,9 @@ $spacing-values: (
 .button,
 .social-icon,
 .navbar-link,
+.navbar-item,
+.link,
 .link-header {
-  letter-spacing: 2px;
   transition: 0.3s;
 }
 

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -122,8 +122,6 @@ $spacing-values: (
 .button,
 .social-icon,
 .navbar-link,
-.navbar-item,
-.link,
 .link-header {
   letter-spacing: 2px;
   transition: 0.3s;


### PR DESCRIPTION
This PR removes the extra letter-spacing applied in _custom.scss to `.link` and `.navbar-item` (and others). It appears that this wasn't needed anywhere because we either didn't want it or it was being overwritten anyway. 

This solves the issues for both #296 and #293 

<img width="165" alt="image" src="https://user-images.githubusercontent.com/16906516/182857440-68657240-cd05-4d31-a08c-e608d51fa07f.png">
<img width="453" alt="image" src="https://user-images.githubusercontent.com/16906516/182857468-ac90d341-b32a-42c3-b15c-f33f7fb59cbe.png">
