### PR TITLE
use all-small-caps for h2 mobile

### DIFF
--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -207,7 +207,7 @@ $body-color: $justfix-black;
   font-weight: 600;
   font-size: 1.125rem;
   letter-spacing: 0.02em;
-  font-variant: small-caps;
+  font-variant: all-small-caps;
 }
 
 @mixin mobile-h3 {

--- a/src/styles/press.scss
+++ b/src/styles/press.scss
@@ -2,7 +2,7 @@
 
 .press-page {
   .jf-press-title {
-    font-variant: small-caps;
+    font-variant: all-small-caps;
   }
   .image {
     border: 1px solid $justfix-black;


### PR DESCRIPTION
Use `all-small-caps` so all letters have the same height 

[sc-10274]

before:
<img width="92" alt="image" src="https://user-images.githubusercontent.com/16906516/182890906-d543a179-201c-410d-9bc3-4f606972c5e0.png">

after:
<img width="92" alt="image" src="https://user-images.githubusercontent.com/16906516/182890863-de05065b-9986-402a-83b8-95733d9a6c33.png">
