### PR TITLE
remove fixed tools button from homepage

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -7,13 +7,9 @@ import { StaticQuery, graphql } from "gatsby";
 
 import Header from "./header";
 import Footer from "./footer";
-import { removeLocaleFromPathname, useCurrentLocale } from "../util/use-locale";
+import { useCurrentLocale } from "../util/use-locale";
 import localeConfig from "../util/locale-config.json";
 import { CookiesBanner } from "./cookies-banner";
-import { useLocation } from "@reach/router";
-import { LocaleLink } from "./locale-link";
-import { Trans } from "@lingui/macro";
-import classnames from "classnames";
 
 const favicon16 = require("../img/brand/favicon-16x16.png");
 const favicon32 = require("../img/brand/favicon-32x32.png");
@@ -77,8 +73,6 @@ const LayoutScaffolding = ({
   }
 
   const locale = useCurrentLocale() || localeConfig.DEFAULT_LOCALE;
-  const { pathname } = useLocation();
-  const isHomepage = removeLocaleFromPathname(pathname) === "";
 
   return (
     <I18nProvider language={locale} catalogs={catalogs}>
@@ -124,25 +118,9 @@ const LayoutScaffolding = ({
       </Helmet>
       <div className="jf-page-body">
         <Header isLandingPage={isLandingPage} />
-        <div
-          className={
-            // Add extra space at bottom of page for fixed footer button:
-            classnames(isHomepage && "mb-12-mobile")
-          }
-        >
-          {children}
-          <Footer />
-          <div className="jf-footer-menu">
-            <CookiesBanner />
-            {isHomepage && (
-              <div className="has-background-black py-5 is-flex is-justify-content-center is-hidden-desktop">
-                <LocaleLink to="/tools" className="button is-primary">
-                  <Trans>See our tools</Trans>
-                </LocaleLink>
-              </div>
-            )}
-          </div>
-        </div>
+        <div>{children}</div>
+        <Footer />
+        <CookiesBanner />
       </div>
     </I18nProvider>
   );

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -178,7 +178,6 @@ msgid "See all articles"
 msgstr ""
 
 #: src/components/header.tsx:111
-#: src/components/layout.tsx:101
 msgid "See our tools"
 msgstr ""
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -183,7 +183,6 @@ msgid "See all articles"
 msgstr "Ver todos los artículos"
 
 #: src/components/header.tsx:111
-#: src/components/layout.tsx:101
 msgid "See our tools"
 msgstr "Ve nuestras herramientas"
 

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -324,15 +324,11 @@ a.has-text-black:hover {
 }
 
 // Content that stays fixed at the bottom of the viewport:
-.jf-footer-menu {
-  width: 100%;
-  position: fixed;
-  bottom: 0;
-  z-index: 30;
-}
-
 .jf-cookies-banner {
   border-top: 1px solid $justfix-black;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
 
   @include wide-desktop {
     width: $wide-desktop;

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -329,6 +329,7 @@ a.has-text-black:hover {
   position: fixed;
   bottom: 0;
   width: 100%;
+  z-index: 30;
 
   @include wide-desktop {
     width: $wide-desktop;


### PR DESCRIPTION
This PR removes the fixed "see our tools" button from the homepage for mobile, reverting #237 

<img width="397" alt="image" src="https://user-images.githubusercontent.com/16906516/183109721-26af6dbd-e7bb-4b2b-8755-71319410a270.png">
