### PR TITLE
Update social links, add instagram and medium

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -81,7 +81,7 @@ const Footer = () => (
         <div className="field mt-3">
           <SocialIcon
             className="mr-3"
-            url="http://twitter.com/justfixnyc"
+            url="http://twitter.com/justfixorg"
             target="_blank"
             rel="noopener noreferrer"
             bgColor="#FFF"
@@ -89,7 +89,7 @@ const Footer = () => (
           />
           <SocialIcon
             className="mr-3"
-            url="https://facebook.com/JustFixNYC"
+            url="https://facebook.com/justfixorg"
             target="_blank"
             rel="noopener noreferrer"
             bgColor="#FFF"
@@ -97,7 +97,7 @@ const Footer = () => (
           />
           <SocialIcon
             className="mr-3"
-            url="https://www.linkedin.com/company/justfix-nyc"
+            url="https://www.linkedin.com/company/justfixorg"
             target="_blank"
             rel="noopener noreferrer"
             bgColor="#FFF"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -68,12 +68,12 @@ const FooterLinksList: React.FC<{ links: LinkWithLabel[] }> = ({ links }) => {
 const Footer = () => (
   <div className="jf-footer has-background-black has-text-white py-7">
     <div className="columns is-multiline">
-      <div className="column is-9 is-12-touch pt-9">
+      <div className="column is-8 is-12-touch pt-9">
         <FooterLanguageToggle />
         <FooterLinksList links={SITE_LINKS} />
       </div>
 
-      <div className="column is-3 is-12-touch">
+      <div className="column is-4 is-12-touch">
         <h4 className="mb-2">
           <Trans>Join our mailing list!</Trans>
         </h4>
@@ -81,7 +81,15 @@ const Footer = () => (
         <div className="field mt-3">
           <SocialIcon
             className="mr-3"
-            url="http://twitter.com/justfixorg"
+            url="https://instagram.com/justfixorg"
+            target="_blank"
+            rel="noopener noreferrer"
+            bgColor="#FFF"
+            style={{ height: 40, width: 40 }}
+          />
+          <SocialIcon
+            className="mr-3"
+            url="https://twitter.com/justfixorg"
             target="_blank"
             rel="noopener noreferrer"
             bgColor="#FFF"
@@ -104,7 +112,15 @@ const Footer = () => (
             style={{ height: 40, width: 40 }}
           />
           <SocialIcon
+            className="mr-3"
             url="https://github.com/JustFixNYC"
+            target="_blank"
+            rel="noopener noreferrer"
+            bgColor="#FFF"
+            style={{ height: 40, width: 40 }}
+          />
+          <SocialIcon
+            url="https://medium.com/justfixorg"
             target="_blank"
             rel="noopener noreferrer"
             bgColor="#FFF"

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -20,7 +20,7 @@ const favicon32 = require("../img/brand/favicon-32x32.png");
 const favicon96 = require("../img/brand/favicon-96x96.png");
 
 const SITE_TITLE_SUFFIX = " | JustFix";
-const TWITTER_HANDLE = "@JustFixNYC";
+const TWITTER_HANDLE = "@JustFixOrg";
 const SITE_MAIN_URL = "https://www.justfix.org";
 const FB_APP_ID = "247990609143668";
 

--- a/src/locales/en/messages.po
+++ b/src/locales/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/footer.tsx:75
+#: src/components/footer.tsx:77
 msgid "<0>Disclaimer:</0> The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr ""
 
-#: src/components/footer.tsx:85
+#: src/components/footer.tsx:86
 msgid "<0>JustFix</0> is a registered 501(c)(3) nonprofit organization."
 msgstr ""
 
@@ -39,7 +39,7 @@ msgstr ""
 
 #: src/components/accordion.tsx:12
 #: src/components/cookies-banner.tsx:32
-#: src/components/header.tsx:119
+#: src/components/header.tsx:120
 msgid "Close"
 msgstr ""
 
@@ -63,11 +63,11 @@ msgstr "Email Address"
 msgid "Expand"
 msgstr ""
 
-#: src/pages/learn.en.tsx:62
+#: src/pages/learn.en.tsx:60
 msgid "Featured Article"
 msgstr ""
 
-#: src/pages/index.en.tsx:101
+#: src/pages/index.en.tsx:117
 msgid "Featured article"
 msgstr ""
 
@@ -98,7 +98,7 @@ msgstr ""
 msgid "Learning Center"
 msgstr ""
 
-#: src/components/header.tsx:119
+#: src/components/header.tsx:120
 msgid "Menu"
 msgstr ""
 
@@ -143,7 +143,7 @@ msgstr ""
 msgid "Press"
 msgstr "Press"
 
-#: src/components/footer.tsx:91
+#: src/components/footer.tsx:92
 msgid "Privacy policy"
 msgstr "Privacy policy"
 
@@ -153,7 +153,7 @@ msgstr ""
 
 #: src/components/read-more.tsx:14
 #: src/components/read-more.tsx:17
-#: src/pages/learn.en.tsx:76
+#: src/pages/learn.en.tsx:75
 msgid "Read More"
 msgstr "Read More"
 
@@ -169,7 +169,7 @@ msgstr ""
 msgid "Search by Algolia"
 msgstr ""
 
-#: src/pages/index.en.tsx:148
+#: src/pages/index.en.tsx:164
 msgid "See all articles"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr "Team"
 msgid "Technology for Housing Justice"
 msgstr ""
 
-#: src/components/footer.tsx:94
+#: src/components/footer.tsx:95
 msgid "Terms of use"
 msgstr "Terms of use"
 
@@ -223,10 +223,10 @@ msgstr ""
 msgid "Tools"
 msgstr ""
 
-#: src/pages/index.en.tsx:109
-#: src/pages/index.en.tsx:127
-#: src/pages/index.en.tsx:140
-#: src/pages/learn.en.tsx:70
+#: src/pages/index.en.tsx:125
+#: src/pages/index.en.tsx:143
+#: src/pages/index.en.tsx:156
+#: src/pages/learn.en.tsx:68
 msgid "Updated"
 msgstr "Updated"
 

--- a/src/locales/es/messages.po
+++ b/src/locales/es/messages.po
@@ -18,11 +18,11 @@ msgstr ""
 "X-Crowdin-File: /master/src/locales/en/messages.po\n"
 "X-Crowdin-File-ID: 19\n"
 
-#: src/components/footer.tsx:75
+#: src/components/footer.tsx:77
 msgid "<0>Disclaimer:</0> The information in JustFix does not constitute legal advice and must not be used as a substitute for the advice of a lawyer qualified to give advice on legal issues pertaining to housing. We can help direct you to free legal services if necessary."
 msgstr "0>Aviso:</0> La información en JustFix no constituye asesoramiento jurídico y no debe ser utilizado como sustituto del asesoramiento de un abogado cualificado para asesorar sobre cuestiones jurídicas relativas a la vivienda. Nosotros podemos ayudarle a dirigirle a servicios legales gratuitos si es necesario."
 
-#: src/components/footer.tsx:85
+#: src/components/footer.tsx:86
 msgid "<0>JustFix</0> is a registered 501(c)(3) nonprofit organization."
 msgstr "<0>JustFix</0> es una organización sin fines de lucro registrada."
 
@@ -44,7 +44,7 @@ msgstr "Empleos"
 
 #: src/components/accordion.tsx:12
 #: src/components/cookies-banner.tsx:32
-#: src/components/header.tsx:119
+#: src/components/header.tsx:120
 msgid "Close"
 msgstr "Cerrar"
 
@@ -68,11 +68,11 @@ msgstr "Correo electrónico"
 msgid "Expand"
 msgstr "Ampliar"
 
-#: src/pages/learn.en.tsx:62
+#: src/pages/learn.en.tsx:60
 msgid "Featured Article"
 msgstr "Artículo destacado"
 
-#: src/pages/index.en.tsx:101
+#: src/pages/index.en.tsx:117
 msgid "Featured article"
 msgstr "Artículo destacado"
 
@@ -103,7 +103,7 @@ msgstr "Aprender más"
 msgid "Learning Center"
 msgstr "Centro de aprendizaje"
 
-#: src/components/header.tsx:119
+#: src/components/header.tsx:120
 msgid "Menu"
 msgstr "Menú"
 
@@ -148,7 +148,7 @@ msgstr "Artículos populares"
 msgid "Press"
 msgstr "Prensa"
 
-#: src/components/footer.tsx:91
+#: src/components/footer.tsx:92
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
@@ -158,7 +158,7 @@ msgstr "Publicado"
 
 #: src/components/read-more.tsx:14
 #: src/components/read-more.tsx:17
-#: src/pages/learn.en.tsx:76
+#: src/pages/learn.en.tsx:75
 msgid "Read More"
 msgstr "Lee más"
 
@@ -174,7 +174,7 @@ msgstr "Buscar"
 msgid "Search by Algolia"
 msgstr "Búsqueda por Algolia"
 
-#: src/pages/index.en.tsx:148
+#: src/pages/index.en.tsx:164
 msgid "See all articles"
 msgstr "Ver todos los artículos"
 
@@ -208,7 +208,7 @@ msgstr "Equipo"
 msgid "Technology for Housing Justice"
 msgstr "Tecnología para la justicia de vivienda"
 
-#: src/components/footer.tsx:94
+#: src/components/footer.tsx:95
 msgid "Terms of use"
 msgstr "Condiciones de uso"
 
@@ -228,10 +228,10 @@ msgstr "Esto significa que podemos ver su ubicación aproximada, el tipo de disp
 msgid "Tools"
 msgstr "Herramientas"
 
-#: src/pages/index.en.tsx:109
-#: src/pages/index.en.tsx:127
-#: src/pages/index.en.tsx:140
-#: src/pages/learn.en.tsx:70
+#: src/pages/index.en.tsx:125
+#: src/pages/index.en.tsx:143
+#: src/pages/index.en.tsx:156
+#: src/pages/learn.en.tsx:68
 msgid "Updated"
 msgstr "Actualizado"
 


### PR DESCRIPTION
Update social links for new .org handles and add Instagram and Medium. To make room for extra icons on desktop the footer columns change from 9/3 to 8/4 and the email signup bar is widened. 

[sc-10522]

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/16906516/183113464-85a2d2ac-9322-4e1f-b29c-ad5e2b4839a7.png">

<img width="382" alt="image" src="https://user-images.githubusercontent.com/16906516/183113348-c5355385-2f50-4ad4-b95f-e55d0ff49ab8.png">
