### PR TITLE
Add custom mobile landing image, increase quality to 100

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -160,13 +160,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
         <Img fluid={props.content.landingImage.fluid} alt="" />
       </div>
       <div className="is-hidden-tablet">
-        <Img
-          fluid={{
-            ...props.content.landingImage.fluid,
-            aspectRatio: 1,
-          }}
-          alt=""
-        />
+        <Img fluid={props.content.landingPageImageMobile.fluid} alt="" />
       </div>
 
       <div className="has-background-black has-text-white">
@@ -340,7 +334,12 @@ export const LandingPageFragment = graphql`
     contentfulHomePage(node_locale: { eq: $locale }) {
       landingLeadInText
       landingImage {
-        fluid {
+        fluid(quality: 100) {
+          ...GatsbyContentfulFluid
+        }
+      }
+      landingPageImageMobile {
+        fluid(quality: 100) {
           ...GatsbyContentfulFluid
         }
       }


### PR DESCRIPTION
Added a `landingPageImageMobile` field to the Home Page contentful model, uses it here:

<img width="328" alt="Screen Shot 2022-08-05 at 12 43 59 PM" src="https://user-images.githubusercontent.com/34112083/183149611-fac8c5a8-1cc1-42ad-8a1c-2c9629c73daa.png">
