### PR TITLE
Increase footer text size/space & fix gatsby background color

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,8 +45,8 @@ const plugins = [
       name: "JustFix",
       short_name: "JustFix",
       start_url: "/",
-      background_color: "#663399",
-      theme_color: "#663399",
+      background_color: "#faf8f4",
+      theme_color: "#faf8f4",
       display: "minimal-ui",
       icon: "src/img/brand/favicon-96x96.png", // This path is relative to the root of the site.
     },

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -38,12 +38,12 @@ export const FooterLanguageToggle = () => {
 
 const FooterLink: React.FC<{ link: LinkWithLabel }> = ({ link }) =>
   link[0].charAt(0) === "/" ? (
-    <Link className="no-underline" to={link[0]}>
-      <p className="title is-4 has-text-white">{link[1]}</p>
+    <Link className="jf-footer-page-link no-underline" to={link[0]}>
+      <p className="title is-4 has-text-white py-3-mobile">{link[1]}</p>
     </Link>
   ) : (
     <OutboundLink className="no-underline" href={link[0]}>
-      <p className="title is-4 has-text-white">{link[1]}</p>
+      <p className="title is-4 has-text-white py-3-mobile">{link[1]}</p>
     </OutboundLink>
   );
 

--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -1,8 +1,24 @@
 @import "_vars.scss";
+@import "_design-system.scss";
 
 .jf-footer {
   input,
   .button {
     height: $spacing-09;
+
+    // en/es button
+    &.eyebrow.is-small {
+      @include mobile {
+        @include mobile-eyebrow;
+      }
+    }
+  }
+
+  .jf-footer-page-link {
+    p {
+      @include mobile {
+        @include mobile-h3;
+      }
+    }
   }
 }


### PR DESCRIPTION
[sc-10583] - [change gatsby theme/bg color to JF white](https://github.com/JustFixNYC/justfix-website/commit/e9d2f92605959f34e1e0f7bc5a1dd5bca0364ce9)

Was looking like this on safari. There is a theme_color ([more info](https://css-tricks.com/meta-theme-color-and-trickery/)) in gatsby setting that is now set to the JF white color. 
<img width="528" alt="image" src="https://user-images.githubusercontent.com/16906516/183508349-42d193e8-e8d8-4a90-a1b6-9f8af6888297.png">


[sc-10581] - [increase size/spacing of footer text elements](https://github.com/JustFixNYC/justfix-website/commit/29a308164e7334f28faaa4a35526b91d94e0967f)

before
<img width="373" alt="image" src="https://user-images.githubusercontent.com/16906516/183508965-eb10f350-1847-4c37-88e6-941caf907e4e.png">


after
<img width="375" alt="image" src="https://user-images.githubusercontent.com/16906516/183508905-c3087191-e307-4df5-9d26-7414f9dac326.png">


[sc-10612]
Later, when we reconcile/refine the design system, we should incorporate some bulma-style `-mobile` classes for typography to make it easier to have different styles on mobile using only classes.