### PR TITLE
override bulma screen sizes, use builtin mixins

### DIFF
--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -331,8 +331,8 @@ a.has-text-black:hover {
   width: 100%;
   z-index: 30;
 
-  @include wide-desktop {
-    width: $wide-desktop;
+  @include widescreen {
+    width: $widescreen;
   }
 
   img {

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -1,25 +1,6 @@
 @import "~bulma/sass/utilities/initial-variables.sass";
 @import "./vars";
-
-// MEDIA:
-
-@mixin mobile {
-  @media screen and (max-width: $desktop) {
-    @content;
-  }
-}
-
-@mixin desktop {
-  @media screen and (min-width: $desktop) {
-    @content;
-  }
-}
-
-@mixin wide-desktop {
-  @media screen and (min-width: $wide-desktop) {
-    @content;
-  }
-}
+@import "~bulma/sass/utilities/mixins.sass";
 
 // FONTS:
 
@@ -291,11 +272,11 @@ $body-color: $justfix-black;
   }
 }
 
-@include desktop() {
+@include desktop {
   @include desktop-typography();
 }
 
-@include mobile() {
+@include mobile {
   @include mobile-typography();
 }
 
@@ -463,13 +444,13 @@ $column-gap: 18px;
 
 // WIDE DESKTOP STYLES:
 
-@include wide-desktop {
+@include widescreen {
   body {
     background-color: $justfix-white;
   }
 
   .jf-page-body {
-    max-width: $wide-desktop;
+    max-width: $widescreen;
     margin: auto;
     box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.25);
   }

--- a/src/styles/_vars.scss
+++ b/src/styles/_vars.scss
@@ -2,7 +2,10 @@
 
 // MEDIA:
 
-$wide-desktop: 1515px;
+$tablet: 769px;
+$desktop: 1146px;
+$widescreen: 1515px;
+$fullhd-enabled: false;
 
 // COLORS:
 

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -27,8 +27,8 @@
   &.jf-sticky {
     position: fixed;
     top: 0;
-    @include wide-desktop {
-      width: $wide-desktop;
+    @include widescreen {
+      width: $widescreen;
     }
   }
 
@@ -163,7 +163,7 @@
 
   // Make only the navbar have absolute position on mobile
   &.is-absolute {
-    @media screen and (max-width: $tablet) {
+    @include mobile {
       position: unset;
 
       .navbar {


### PR DESCRIPTION
[sc-10660]

This PR overrides bulma defaults for screen sizes to use a smaller desktop value so it switches to tablet view before the top menu bar gets squeezed. 

This also changes to use the [builtin bulma responsive mixins](https://bulma.io/documentation/utilities/responsive-mixins/) instead of recreating these ourselves. 