### PR TITLE
tablet use desktop text styles and mobile layout

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -48,20 +48,20 @@ export const ProductCard: React.FC<ProductCardInfo> = (props) => {
     <div
       className={classnames(
         "column is-4 is-12-touch",
-        props.isCondensed && "pl-0 pr-6 px-0-mobile"
+        props.isCondensed && "pl-0 pr-6 px-0-touch"
       )}
     >
       <div
         className={classnames(
           "jf-card has-background-white",
-          props.isCondensed ? "p-6" : "p-8 p-6-mobile"
+          props.isCondensed ? "p-6" : "p-8 p-6-touch"
         )}
       >
-        <div className="eyebrow is-small mb-5 mb-4-mobile">
+        <div className="eyebrow is-small mb-5 mb-4-touch">
           {props.productName}
         </div>
-        <h3 className="mb-6 mb-5-mobile">{props.title}</h3>
-        <div className="title is-4 mb-6 mb-5-mobile">
+        <h3 className="mb-6 mb-5-touch">{props.title}</h3>
+        <div className="title is-4 mb-6 mb-5-touch">
           {documentToReactComponents(props.descriptionText.json)}
         </div>
         <div className="mt-auto">
@@ -104,18 +104,18 @@ type ProductListInfo = {
 export const ProductList: React.FC<ProductListInfo> = (props) => (
   <div
     id="products"
-    className="has-background-link has-text-black pb-12 pb-6-mobile"
+    className="has-background-link has-text-black pb-12 pb-6-touch"
   >
     <div className="columns is-multiline">
-      <div className="column is-12 pt-10 pt-7-mobile pb-9">
+      <div className="column is-12 pt-10 pt-7-touch pb-9">
         <h1>{props.productSectionTitle}</h1>
       </div>
       {props.homePageProductBlocks.map((product: any, i: number) => (
         <ProductCard {...product} key={i} />
       ))}
       <div className="column is-4 is-12-touch">
-        <div className="jf-card has-background-black has-text-white p-8 p-6-mobile">
-          <div className="mb-6 mb-9-mobile">
+        <div className="jf-card has-background-black has-text-white p-8 p-6-touch">
+          <div className="mb-6 mb-9-touch">
             {documentToReactComponents(props.productIdeaBanner.content.json)}
           </div>
 
@@ -134,22 +134,22 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
 export const LandingPageScaffolding = (props: ContentfulContent) => (
   <Layout isLandingPage={true}>
     <div id="home" className="home-page">
-      <div className="is-hidden-mobile">
+      <div className="is-hidden-touch">
         <Img fluid={props.content.landingImage.fluid} alt="" />
       </div>
-      <div className="is-hidden-tablet">
+      <div className="is-hidden-desktop">
         <Img fluid={props.content.landingPageImageMobile.fluid} alt="" />
       </div>
 
       <div className="has-background-black has-text-white">
         <div className="columns">
-          <div className="column is-12 pt-9 py-8-mobile">
-            <h1 className="is-inline-desktop">
+          <div className="column is-12 pt-9 py-8-touch">
+            <h1 className="is-inline-tablet">
               {props.content.whoWeAreSection}
             </h1>
             <Link
               to={props.content.whoWeAreButton.link}
-              className="button is-primary is-inline-block-desktop mt-5 mb-10 mb-7-mobile ml-5 ml-0-mobile"
+              className="button is-primary is-inline-block-tablet mt-5 mb-10 mb-7-touch ml-5 ml-0-mobile"
             >
               {props.content.whoWeAreButton.title}
             </Link>
@@ -159,9 +159,9 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
 
       <ProductList {...props.content} />
 
-      <div className="jf-learning-center-preview mb-12 mb-0-mobile">
+      <div className="jf-learning-center-preview mb-12 mb-0-touch">
         <div className="columns">
-          <div className="column is-12 pt-10 pt-7-mobile pb-9 pb-5-mobile">
+          <div className="column is-12 pt-10 pt-7-touch pb-9 pb-5-touch">
             <h1>{props.content.learningCenterPreviewTitle}</h1>
             <h3 className="mt-2">
               {props.content.learningCenterPreviewSubtitle}
@@ -249,21 +249,21 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
         </div>
       </div>
 
-      <div className="mb-12 mb-9-mobile">
+      <div className="mb-12 mb-9-touch">
         <div className="columns is-multiline">
           <div className="column is-6 is-12-touch is-flex is-flex-direction-column">
             <h1 className="mb-6">{props.content.partnershipsSectionTitle}</h1>
-            <div className="has-background-success p-8 p-6-mobile is-flex-grow-1 is-flex is-flex-direction-column">
+            <div className="has-background-success p-8 p-6-touch is-flex-grow-1 is-flex is-flex-direction-column">
               <ResponsiveElement
                 desktop="h2"
                 touch="h3"
-                className="py-5 pt-0-mobile mb-8"
+                className="py-5 pt-0-touch mb-8"
               >
                 {props.content.partnershipsSectionSubtitle}
               </ResponsiveElement>
               <Link
                 to={props.content.partnershipsSectionButton.link}
-                className="button is-primary mb-5 mb-4-mobile is-align-self-flex-start"
+                className="button is-primary mb-5 mb-4-touch is-align-self-flex-start"
               >
                 {props.content.partnershipsSectionButton.title}
               </Link>
@@ -271,17 +271,17 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
           </div>
           <div className="column is-6 is-12-touch is-flex is-flex-direction-column">
             <h1 className="mb-6">{props.content.policySectionTitle}</h1>
-            <div className="has-background-link p-8 p-6-mobile is-flex-grow-1 is-flex is-flex-direction-column">
+            <div className="has-background-link p-8 p-6-touch is-flex-grow-1 is-flex is-flex-direction-column">
               <ResponsiveElement
                 desktop="h2"
                 touch="h3"
-                className="py-5 pt-0-mobile mb-8"
+                className="py-5 pt-0-touch mb-8"
               >
                 {props.content.policySectionSubtitle}
               </ResponsiveElement>
               <Link
                 to={props.content.policySectionButton.link}
-                className="button is-primary mb-5 mb-4-mobile is-align-self-flex-start"
+                className="button is-primary mb-5 mb-4-touch is-align-self-flex-start"
               >
                 {props.content.policySectionButton.title}
               </Link>
@@ -291,8 +291,8 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
       </div>
 
       <div className="columns has-background-info">
-        <div className="column is-12 pt-9 pt-6-mobile pb-12 pb-9-mobile">
-          <h1 className="is-inline-desktop">
+        <div className="column is-12 pt-9 pt-6-touch pb-12 pb-9-touch">
+          <h1 className="is-inline-tablet">
             {props.content.outroSectionTitle}
           </h1>
           <Link

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -47,7 +47,7 @@ export const ProductCard: React.FC<ProductCardInfo> = (props) => {
   return (
     <div
       className={classnames(
-        "column is-4 is-12-mobile",
+        "column is-4 is-12-touch",
         props.isCondensed && "pl-0 pr-6 px-0-mobile"
       )}
     >
@@ -113,7 +113,7 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
       {props.homePageProductBlocks.map((product: any, i: number) => (
         <ProductCard {...product} key={i} />
       ))}
-      <div className="column is-4 is-12-mobile">
+      <div className="column is-4 is-12-touch">
         <div className="jf-card has-background-black has-text-white p-8 p-6-mobile">
           <div className="mb-6 mb-9-mobile">
             {documentToReactComponents(props.productIdeaBanner.content.json)}
@@ -250,8 +250,8 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
       </div>
 
       <div className="mb-12 mb-9-mobile">
-        <div className="columns">
-          <div className="column is-6 is-12-mobile is-flex is-flex-direction-column">
+        <div className="columns is-multiline">
+          <div className="column is-6 is-12-touch is-flex is-flex-direction-column">
             <h1 className="mb-6">{props.content.partnershipsSectionTitle}</h1>
             <div className="has-background-success p-8 p-6-mobile is-flex-grow-1 is-flex is-flex-direction-column">
               <ResponsiveElement
@@ -269,7 +269,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
               </Link>
             </div>
           </div>
-          <div className="column is-6 is-12-mobile is-flex is-flex-direction-column">
+          <div className="column is-6 is-12-touch is-flex is-flex-direction-column">
             <h1 className="mb-6">{props.content.policySectionTitle}</h1>
             <div className="has-background-link p-8 p-6-mobile is-flex-grow-1 is-flex is-flex-direction-column">
               <ResponsiveElement

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -92,7 +92,7 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
       .reduce((cat1, cat2, i) => [cat1, <Dot key={Math.random()} />, cat2]);
 
   return (
-    <div className="column is-8 py-0">
+    <div className="column is-8 is-12-touch py-0">
       <div
         className={classnames(
           "jf-article-card ",
@@ -106,10 +106,10 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
           className={classnames(
             "pt-7 mb-2",
             isFeatured ? "pb-7 px-6" : "px-0",
-            !isFeatured && !props.isLast ? "pb-0-mobile" : ""
+            !isFeatured && !props.isLast ? "pb-0-touch" : ""
           )}
         >
-          <div className="mt-2 mb-6 mb-3-mobile">
+          <div className="mt-2 mb-6 mb-3-touch">
             {isFeatured ? (
               <span className="eyebrow">
                 <Trans>Featured Article</Trans>
@@ -118,20 +118,20 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
               <div className="jf-category-labels">{categoryLabels}</div>
             )}
           </div>
-          <div className="mb-6 mb-3-mobile">
+          <div className="mb-6 mb-3-touch">
             <LocaleLink className={"jf-link-article"} to={articleUrl}>
-              <h3 className="mb-6 mb-3-mobile">{props.title}</h3>
+              <h3 className="mb-6 mb-3-touch">{props.title}</h3>
             </LocaleLink>
-            <span className="is-hidden-mobile eyebrow is-small">
+            <span className="is-hidden-touch eyebrow is-small">
               <Trans>Updated</Trans> {formatDate(props.dateUpdated, locale)}
             </span>
-            <h4 className="my-6 my-3-mobile">{props.metadata.description}</h4>
+            <h4 className="my-6 my-3-touch">{props.metadata.description}</h4>
           </div>
           <div className="is-flex">
             {isFeatured ? (
               <div className="jf-article-link-container is-flex is-flex-direction-row">
                 <LocaleLink
-                  className={"button is-primary mt-0 mt-4-mobile"}
+                  className={"button is-primary mt-0 mt-4-touch"}
                   to={articleUrl}
                 >
                   <Trans>Read More</Trans>
@@ -165,12 +165,12 @@ export const LearningPageScaffolding = (props: ContentfulContent) => {
   return (
     <Layout metadata={props.content.metadata}>
       <div id="learning-center" className="learning-center-page">
-        <div className="columns is-centered is-multiline pt-12 pt-7-mobile pb-10">
-          <div className="column is-8 pb-0 mb-12">
+        <div className="columns is-centered is-multiline pt-12 pt-7-touch pb-10">
+          <div className="column is-8 is-12-touch pb-0 mb-12">
             <span className="eyebrow is-uppercase">
               <Trans>Learning Center</Trans>
             </span>
-            <h1 className="mt-2 mt-4-mobile mb-6">{props.content.title}</h1>
+            <h1 className="mt-2 mt-4-touch mb-6">{props.content.title}</h1>
             <LearningSearchBar props={props.content} />
           </div>
           <ArticlePreviewCard {...props.content.featuredArticle} />

--- a/src/pages/our-mission.en.tsx
+++ b/src/pages/our-mission.en.tsx
@@ -20,28 +20,28 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
       <div id="our-mission" className="our-mission-page">
         <PageHero {...props.content.pageHero} />
 
-        <div className="columns">
-          <div className="column is-4 pt-13 pb-12 p-6-mobile">
+        <div className="columns is-multiline">
+          <div className="column is-4 is-12-touch pt-13 pb-12 p-6-touch">
             <ResponsiveElement desktop="h2" touch="h1">
               {props.content.missionTitle}
             </ResponsiveElement>
           </div>
-          <div className="column is-1 is-hidden-mobile" />
-          <div className="column is-7 pt-13 pb-12 pt-0-mobile px-6-mobile pb-6-mobile">
+          <div className="column is-1 is-hidden-touch" />
+          <div className="column is-7 is-12-touch pt-13 pb-12 pt-0-touch px-6-touch pb-6-touch">
             <span className="title is-3">
               {documentToReactComponents(props.content.missionContent.json)}
             </span>
           </div>
         </div>
 
-        <div className="columns has-background-warning">
-          <div className="column is-4 pt-13 pb-12 pt-6-mobile px-6-mobile pb-0-mobile">
+        <div className="columns has-background-warning is-multiline">
+          <div className="column is-4 is-12-touch pt-13 pb-12 pt-6-touch px-6-touch pb-0-touch">
             <ResponsiveElement desktop="h2" touch="h1">
               {props.content.visionTitle}
             </ResponsiveElement>
           </div>
-          <div className="column is-1 is-hidden-mobile" />
-          <div className="column is-7 pt-13 pb-12 p-6-mobile jf-text-block-with-spacing">
+          <div className="column is-1 is-hidden-touch" />
+          <div className="column is-7 is-12-touch pt-13 pb-12 p-6-touch jf-text-block-with-spacing">
             <ResponsiveElement desktop="h3" touch="h2">
               {props.content.visionSubtitle}
             </ResponsiveElement>
@@ -55,21 +55,19 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
           </div>
         </div>
 
-        <div className="columns">
-          <div className="column is-4 pt-13 pb-12 pt-6-mobile px-6-mobile pb-0-mobile">
+        <div className="columns is-multiline">
+          <div className="column is-4 is-12-touch pt-13 pb-12 pt-6-touch px-6-touch pb-0-touch">
             <ResponsiveElement desktop="h2" touch="h1">
               {props.content.impactTitle}
             </ResponsiveElement>
           </div>
-          <div className="column is-1 is-hidden-mobile" />
-          <div className="column is-7 pt-13 pb-12 p-6-mobile">
-            <h3 className="mb-10 mb-6-mobile">
-              {props.content.impactSubtitle}
-            </h3>
-            <div className="columns is-paddingless">
-              <div className="column is-9 has-background-black has-text-white">
-                <div className="columns is-paddingless">
-                  <div className="column is-7">
+          <div className="column is-1 is-hidden-touch" />
+          <div className="column is-7 is-12-touch pt-13 pb-12 p-6-touch">
+            <h3 className="mb-10 mb-6-touch">{props.content.impactSubtitle}</h3>
+            <div className="columns is-paddingless is-multiline">
+              <div className="column is-9 is-12-touch has-background-black has-text-white">
+                <div className="columns is-paddingless is-multiline">
+                  <div className="column is-7 ">
                     <ResponsiveElement desktop="h2" touch="h1">
                       {latestReport.title}
                     </ResponsiveElement>
@@ -85,7 +83,7 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
               </div>
             </div>
             <ResponsiveElement
-              className="mt-10 mb-7 my-6-mobile"
+              className="mt-10 mb-7 my-6-touch"
               desktop="h3"
               touch="h2"
             >
@@ -104,22 +102,22 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
           </div>
         </div>
 
-        <div className="columns has-background-info">
-          <div className="column is-4 pt-13 pb-12 p-6-mobile">
+        <div className="columns has-background-info is-multiline">
+          <div className="column is-4 is-12-touch pt-13 pb-12 p-6-touch">
             <ResponsiveElement desktop="h2" touch="h1">
               {props.content.valuesTitle}
             </ResponsiveElement>
           </div>
-          <div className="column is-1 is-hidden-mobile" />
-          <div className="column is-7 pt-13 pb-12 p-6-mobile">
+          <div className="column is-1 is-hidden-touch" />
+          <div className="column is-7 is-12-touch pt-13 pb-12 p-6-touch">
             {props.content.valuesList.map((value: any, i: number) => (
               <div key={i}>
                 {i > 0 && <div className="is-divider" />}
-                <div className="is-hidden-mobile">
+                <div className="is-hidden-touch">
                   <h3 className="mb-5">{value.title}</h3>
                   <p className="title is-4">{value.description.description}</p>
                 </div>
-                <div className="is-hidden-tablet">
+                <div className="is-hidden-desktop">
                   <Accordion question={value.title}>
                     <p>{value.description.description}</p>
                   </Accordion>

--- a/src/pages/partners.en.tsx
+++ b/src/pages/partners.en.tsx
@@ -43,7 +43,7 @@ const formatLinkLabel = (link: string) => {
 };
 
 const PartnerCard: React.FC<PartnerDetails> = ({ name, link, logo }) => (
-  <div className="column is-3 jf-partner-card pl-0 pr-7 is-hidden-mobile">
+  <div className="column is-3 jf-partner-card pl-0 pr-7 is-hidden-touch">
     <div className="has-background-white is-flex is-flex-direction-column is-align-items-center is-justify-content-space-between">
       <div className="has-background-black has-text-white">
         <div className="eyebrow is-large has-text-centered is-flex is-flex-direction-column is-justify-content-center">
@@ -68,7 +68,7 @@ const PartnerCard: React.FC<PartnerDetails> = ({ name, link, logo }) => (
 );
 
 const PartnerCardMobile: React.FC<PartnerDetails> = ({ name, link, logo }) => (
-  <div className="column is-3 jf-partner-card jf-accordion-item p-0 is-hidden-tablet">
+  <div className="column is-12 jf-partner-card jf-accordion-item p-0 is-hidden-desktop">
     <details className="has-background-white">
       <summary className="has-background-black has-text-white">
         <div className="eyebrow is-large is-flex is-flex-direction-row is-align-items-center is-justify-content-space-between px-5">
@@ -111,14 +111,14 @@ const PartnersSection: React.FC<PartnersSectionDetails> = ({
   partners,
 }) => (
   <div className="columns has-background-info">
-    <div className="column pt-12 pb-10 p-6-mobile">
-      <h2 className="pb-3 pb-6-mobile">
+    <div className="column pt-12 pb-10 p-6-touch">
+      <h2 className="pb-3 pb-6-touch">
         {title}{" "}
         <span className="has-text-weight-bold is-hidden-tablet">
           ({letterRange})
         </span>
       </h2>
-      <h3 className="is-hidden-mobile mb-11">{letterRange}</h3>
+      <h3 className="is-hidden-touch mb-11">{letterRange}</h3>
       <div className="columns is-paddingless is-multiline">
         {partners
           // Sort alphabetically:
@@ -147,10 +147,10 @@ const PartnershipCaseStudy: React.FC<PartnershipCaseStudyDetails> = ({
   description,
 }) => (
   <div className="columns has-background-info is-multiline">
-    <div className="column is-12 pt-0-mobile">
-      <div className="is-divider my-10 my-0-mobile" />
+    <div className="column is-12 pt-0-touch">
+      <div className="is-divider my-10 my-0-touch" />
     </div>
-    <div className="column is-4 my-6 my-0-mobile">
+    <div className="column is-4 is-12-touch my-6 my-0-touch">
       <div className="eyebrow is-large mb-3">
         <Trans>Partnership case study</Trans>
       </div>
@@ -158,13 +158,13 @@ const PartnershipCaseStudy: React.FC<PartnershipCaseStudyDetails> = ({
         {title}
       </ResponsiveElement>
     </div>
-    <div className="column is-8 my-6 my-0-mobile">
+    <div className="column is-8 is-12-touch my-6 my-0-touch">
       <span className="title is-4">
         {documentToReactComponents(description.json)}
       </span>
     </div>
     <div className="column is-12 is-paddingless">
-      <div className="is-divider mt-9 mb-0 my-0-mobile" />
+      <div className="is-divider mt-9 mb-0 my-0-touch" />
     </div>
   </div>
 );
@@ -174,14 +174,14 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
     <div id="partners" className="partners-page">
       <PageHero {...props.content.pageHero} />
 
-      <div className="columns">
-        <div className="column is-4 pt-13 pb-12 p-6-mobile">
+      <div className="columns is-multiline">
+        <div className="column is-4 is-12-touch pt-13 pb-12 p-6-touch">
           <ResponsiveElement desktop="h2" touch="h1">
             {props.content.title}
           </ResponsiveElement>
         </div>
-        <div className="column is-1 is-hidden-mobile" />
-        <div className="column is-7 pt-13 pb-12 pt-0-mobile px-6-mobile pb-6-mobile">
+        <div className="column is-1 is-hidden-touch" />
+        <div className="column is-7 is-12-touch pt-13 pb-12 pt-0-touch px-6-touch pb-6-touch">
           <span className="title is-3">{props.content.subtitle.subtitle}</span>
         </div>
       </div>
@@ -251,14 +251,14 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
       </div>
 
       <div className="columns">
-        <div className="column pt-13 pb-12 p-6-mobile">
-          <div className="columns is-paddingless">
-            <div className="column is-5 mb-12 mb-0-mobile px-0-mobile pb-4-mobile">
+        <div className="column pt-13 pb-12 p-6-touch">
+          <div className="columns is-multiline is-paddingless">
+            <div className="column is-5 is-12-touch mb-12 mb-0-touch px-0-touch pb-4-touch">
               <ResponsiveElement desktop="h2" touch="h1">
                 {props.content.fundersTitle}
               </ResponsiveElement>
             </div>
-            <div className="column mb-12 mb-6-mobile px-0-mobile">
+            <div className="column mb-12 mb-6-touch px-0-touch">
               <h3>{props.content.fundersSubtitle}</h3>
             </div>
           </div>

--- a/src/pages/press.en.tsx
+++ b/src/pages/press.en.tsx
@@ -35,7 +35,7 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns is-centered is-multiline pt-7">
           {props.content.pressItems.map((press: any, i: number) => (
-            <div className="column is-8 pt-0" key={i}>
+            <div className="column is-8 is-12-touch pt-0" key={i}>
               {i > 0 &&
                 !press.isFeaturedArticle &&
                 !props.content.pressItems[i - 1].isFeaturedArticle && (
@@ -79,7 +79,7 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
               </div>
             </div>
           ))}
-          <div className="column is-8 has-background-black has-text-white py-10 px-7 mt-6 mb-12 mx-5-mobile">
+          <div className="column is-8 is-12-touch has-background-black has-text-white py-10 px-7 mt-6 mb-12 mx-5-touch">
             <ResponsiveElement desktop="h2" touch="h3" className="mb-6">
               {documentToReactComponents(
                 props.content.pressInquiryBanner.content.json

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -36,9 +36,9 @@ type ReportCardInfo = {
 };
 
 const ReportCard: React.FC<ReportCardInfo> = (props) => (
-  <div className="mt-6 mb-9 mt-0-mobile">
+  <div className="mt-6 mb-9 mt-0-touch">
     <div className="jf-report-card columns is-paddingless is-multiline has-background-white">
-      <div className="column is-6 is-paddingless">
+      <div className="column is-6 is-12-touch is-paddingless">
         <Img
           fluid={props.image.fluid}
           objectFit="cover"
@@ -47,7 +47,7 @@ const ReportCard: React.FC<ReportCardInfo> = (props) => (
           className="jf-report-img"
         />
       </div>
-      <div className="column is-6 px-9 px-6-mobile pt-8 pb-11 py-7-mobile is-flex is-flex-direction-column">
+      <div className="column is-6 is-12-touch px-9 px-6-touch pt-8 pb-11 py-7-touch is-flex is-flex-direction-column">
         <ResponsiveElement
           desktop="h2"
           touch="h3"
@@ -79,16 +79,16 @@ export const PolicyPageScaffolding = (props: ContentfulContent) => {
       <div id="reports" className="reports-page">
         <PageHero {...props.content.pageHero} />
 
-        <div className="columns pt-13 pb-11 p-6-mobile">
-          <div className="column is-4 py-0 p-0-mobile">
+        <div className="columns is-multiline pt-13 pb-11 p-6-touch">
+          <div className="column is-4 is-12-touch py-0 p-0-touch">
             <ResponsiveElement
               desktop="h2"
               touch="h1"
               children={props.content.approachTitle}
             />
           </div>
-          <div className="column is-1 is-hidden-mobile" />
-          <div className="column is-7 py-0 pt-6-mobile px-0-mobile">
+          <div className="column is-1 is-hidden-touch" />
+          <div className="column is-7 is-12-touch py-0 pt-6-touch px-0-touch">
             <span className="title is-3">
               {documentToReactComponents(props.content.approachContent.json)}
             </span>
@@ -97,16 +97,16 @@ export const PolicyPageScaffolding = (props: ContentfulContent) => {
 
         <div
           id="report-section"
-          className="columns pt-10 pb-12 pt-0-mobile pb-8-mobile"
+          className="columns is-multiline pt-10 pb-12 pt-0-touch pb-8-touch"
         >
-          <div className="column is-3">
+          <div className="column is-3 is-12-touch">
             <ResponsiveElement
               desktop="h2"
               touch="h1"
               children={props.content.reportsTitle}
             />
           </div>
-          <div className="column is-9 pb-9 py-0-mobile">
+          <div className="column is-9 is-12-touch pb-9 py-0-touch">
             {props.content.reportBlocks.map((report: any, i: number) => (
               <ReportCard {...report} locale={locale} key={i} />
             ))}

--- a/src/pages/team.en.tsx
+++ b/src/pages/team.en.tsx
@@ -23,7 +23,7 @@ type MemberCardInfo = {
 
 const MemberCard: React.FC<MemberCardInfo> = (props) => (
   <div
-    className={`jf-member-card column is-9 px-6 py-9 py-6-mobile  ${props.className}`}
+    className={`jf-member-card column is-9 is-12-touch px-6 py-9 py-6-touch  ${props.className}`}
   >
     <figure className="image">
       <Img fluid={props.photo.fluid} className="is-rounded" alt={props.name} />
@@ -45,7 +45,7 @@ type MemberCardsListInfo = {
 
 const MemberCardsList: React.FC<MemberCardsListInfo> = (props) => (
   <>
-    <h1 className="jf-team-title pl-9 pt-6 pl-0-mobile pt-3-mobile">
+    <h1 className="jf-team-title pl-9 pt-6 pl-0-touch pt-3-touch">
       {props.sectionTitle}
     </h1>
     <div className="jf-members columns is-multiline is-centered">
@@ -56,7 +56,7 @@ const MemberCardsList: React.FC<MemberCardsListInfo> = (props) => (
           "is-pulled-right",
         ];
         return (
-          <div className="column is-4 is-paddingless" key={i}>
+          <div className="column is-4 is-12-touch is-paddingless" key={i}>
             <MemberCard {...member} className={alignments[i % 3]} />
           </div>
         );
@@ -92,7 +92,7 @@ export const TeamPageScaffolding = (props: ContentfulContent) => (
           </div>
         </div>
         <div className="columns">
-          <div className="jf-alumni-list column is-8 is-12-mobile">
+          <div className="jf-alumni-list column is-8 is-12-touch">
             {props.content.otherContributors.map(
               (contributor: any, i: number) => (
                 <p className="py-4" key={i}>

--- a/src/pages/tools.en.tsx
+++ b/src/pages/tools.en.tsx
@@ -44,7 +44,7 @@ export const ToolsPageScaffolding = (props: ContentfulContent) => {
         </div>
         {props.content.pastToolsBlocks.map((tool: any, i: number) => (
           <div
-            className="column is-3 is-12-mobile pt-0 pb-10 pb-7-mobile"
+            className="column is-3 is-12-touch pt-0 pb-10 pb-7-mobile"
             key={i}
           >
             <h3 className="mb-3">{tool.toolName}</h3>

--- a/src/pages/tools.en.tsx
+++ b/src/pages/tools.en.tsx
@@ -39,12 +39,12 @@ export const ToolsPageScaffolding = (props: ContentfulContent) => {
       />
 
       <div className="columns is-multiline">
-        <div className="column is-12 my-9 mb-6-mobile">
+        <div className="column is-12 my-9 mb-6-touch">
           <h2>{props.content.pastToolsTitle}</h2>
         </div>
         {props.content.pastToolsBlocks.map((tool: any, i: number) => (
           <div
-            className="column is-3 is-12-touch pt-0 pb-10 pb-7-mobile"
+            className="column is-3 is-12-touch pt-0 pb-10 pb-7-touch"
             key={i}
           >
             <h3 className="mb-3">{tool.toolName}</h3>
@@ -62,13 +62,13 @@ export const ToolsPageScaffolding = (props: ContentfulContent) => {
       </div>
 
       <div className="columns has-background-success">
-        <div className="column is-12 pt-9 pt-6-mobile pb-12 pb-9-mobile">
+        <div className="column is-12 pt-9 pt-6-touch pb-12 pb-9-touch">
           <h1 className="is-inline-desktop">
             {props.content.outroSectionTitle}
           </h1>
           <Link
             to={props.content.outroSectionButton.link}
-            className="button is-primary mt-5 ml-5 ml-0-mobile"
+            className="button is-primary mt-5 ml-5 ml-0-touch"
           >
             {props.content.outroSectionButton.title}
           </Link>

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -53,6 +53,11 @@ $spacing-values: (
         #{$property}: $value !important;
       }
     }
+    .#{$shortcut}-#{$name}-touch {
+      @include touch {
+        #{$property}: $value !important;
+      }
+    }
     // Cardinal directions
     @each $direction, $suffix in $spacing-directions {
       .#{$shortcut}#{$suffix}-#{$name} {
@@ -60,6 +65,11 @@ $spacing-values: (
       }
       .#{$shortcut}#{$suffix}-#{$name}-mobile {
         @include mobile {
+          #{$property}-#{$direction}: $value !important;
+        }
+      }
+      .#{$shortcut}#{$suffix}-#{$name}-touch {
+        @include touch {
           #{$property}-#{$direction}: $value !important;
         }
       }
@@ -76,6 +86,12 @@ $spacing-values: (
           #{$property}-right: $value !important;
         }
       }
+      .#{$shortcut}#{$spacing-horizontal}-#{$name}-touch {
+        @include touch {
+          #{$property}-left: $value !important;
+          #{$property}-right: $value !important;
+        }
+      }
     }
     // Vertical axis
     @if $spacing-vertical != null {
@@ -85,6 +101,12 @@ $spacing-values: (
       }
       .#{$shortcut}#{$spacing-vertical}-#{$name}-mobile {
         @include mobile {
+          #{$property}-top: $value !important;
+          #{$property}-bottom: $value !important;
+        }
+      }
+      .#{$shortcut}#{$spacing-vertical}-#{$name}-touch {
+        @include touch {
           #{$property}-top: $value !important;
           #{$property}-bottom: $value !important;
         }

--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -272,7 +272,7 @@ $body-color: $justfix-black;
   }
 }
 
-@include desktop {
+@include tablet {
   @include desktop-typography();
 }
 

--- a/src/styles/header.scss
+++ b/src/styles/header.scss
@@ -9,7 +9,7 @@
   background-color: $white;
   height: $navbar-height;
 
-  @include mobile {
+  @include touch {
     height: $navbar-height-mobile;
   }
 
@@ -37,7 +37,7 @@
     border-bottom: 1px solid $black;
     z-index: inherit;
 
-    @include mobile {
+    @include touch {
       height: $navbar-height-mobile;
       min-height: unset;
     }
@@ -51,7 +51,7 @@
         transition: none;
         color: $black;
 
-        @include mobile {
+        @include touch {
           width: 50%;
         }
 
@@ -124,7 +124,7 @@
         margin-left: auto;
       }
 
-      @include mobile {
+      @include touch {
         width: 100%;
         height: calc(100vh - #{$navbar-height-mobile});
       }
@@ -163,7 +163,7 @@
 
   // Make only the navbar have absolute position on mobile
   &.is-absolute {
-    @include mobile {
+    @include touch {
       position: unset;
 
       .navbar {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -38,7 +38,7 @@
         border-right: 1px solid $justfix-black;
       }
 
-      @include mobile {
+      @include touch {
         border-bottom: 1px solid $justfix-black;
       }
     }

--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -41,7 +41,7 @@
       a,
       u,
       span {
-        @include desktop {
+        @include tablet {
           @include desktop-text-small;
         }
         @include mobile {
@@ -63,7 +63,7 @@
     }
   }
   .jf-article-link-container {
-    @include mobile {
+    @include touch {
       justify-content: center;
     }
   }

--- a/src/styles/reports.scss
+++ b/src/styles/reports.scss
@@ -11,7 +11,7 @@
         border-radius: 0.25rem 0 0 0.25rem; // 4px
         height: 100%;
 
-        @include mobile {
+        @include touch {
           border-radius: 0.25rem 0.25rem 0 0; // 4px
           height: 15rem; // 240px
         }

--- a/src/styles/team.scss
+++ b/src/styles/team.scss
@@ -2,7 +2,7 @@
 
 #team {
   .jf-team-title {
-    @include mobile {
+    @include touch {
       text-align: center;
     }
   }
@@ -13,7 +13,7 @@
   }
 
   .jf-member-card {
-    @include mobile {
+    @include touch {
       float: left;
     }
   }


### PR DESCRIPTION
This PR does a first rough pass for tablet styles to serve as a baseline/reference for pairing with Tahnee tomorrow to refine. For tablet it uses the mobile layouts but the desktop text styles. 

This PR also creates new `-touch` custom spacing classes, and uses those throughout instead of `-mobile`. Originally we had been using custom media query mixin called "mobile" to cover mobile and tablet, but now we're following the [bulma system for specifying responsive sizes](https://bulma.io/documentation/overview/responsiveness/#breakpoints) and call that `touch`. 

[sc-10662]