### PR TITLE
make ResponsiveElement more flexible for sizes

### DIFF
--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -151,8 +151,7 @@ const LearningArticle = (props: Props) => {
             </nav>
 
             <ResponsiveElement
-              desktop="h2"
-              touch="h1"
+              tagNames={{ desktop: "h2", touch: "h1" }}
               className="mt-2 mb-6 my-5-mobile"
             >
               {content.title}
@@ -211,7 +210,10 @@ const LearningArticle = (props: Props) => {
                   ))
                 ) : (
                   <div className="jf-all-tools-card column is-6 has-background-link mt-6 py-8 px-6">
-                    <ResponsiveElement desktop="h4" touch="h2" className="mb-5">
+                    <ResponsiveElement
+                      tagNames={{ desktop: "h4", touch: "h2" }}
+                      className="mb-5"
+                    >
                       <Trans>
                         Assert your tenant rights by using our digital tools
                       </Trans>

--- a/src/components/learning-center/category-page-template.tsx
+++ b/src/components/learning-center/category-page-template.tsx
@@ -32,7 +32,10 @@ const LearningCategoryPage = (props: Props) => {
             <span className="eyebrow is-large">
               <Trans>Learning Center</Trans>
             </span>
-            <ResponsiveElement desktop="h1" touch="h2" className="mb-6">
+            <ResponsiveElement
+              tagNames={{ desktop: "h1", touch: "h2" }}
+              className="mb-6"
+            >
               {content.title}
             </ResponsiveElement>
             <h3>{content.description}</h3>

--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -32,8 +32,7 @@ const PageHero: React.FC<PageHeroInfo> = ({
         <div className="column is-6 px-10 py-9 p-6-mobile is-flex is-align-items-flex-end">
           <div>
             <ResponsiveElement
-              desktop="h2"
-              touch="h1"
+              tagNames={{ desktop: "h2", touch: "h1" }}
               className="mb-9 mb-5-mobile"
             >
               {description}

--- a/src/components/responsive-element.tsx
+++ b/src/components/responsive-element.tsx
@@ -4,30 +4,51 @@ import classnames from "classnames";
 type ResponsiveElementTagName = "h1" | "h2" | "h3" | "h4" | "p";
 
 type ResponsiveElementInfo = {
-  desktop: ResponsiveElementTagName;
-  touch: ResponsiveElementTagName;
   children: React.ReactNode;
+  mobile?: ResponsiveElementTagName;
+  tabletOnly?: ResponsiveElementTagName;
+  desktopOnly?: ResponsiveElementTagName;
+  widescreenOnly?: ResponsiveElementTagName;
+  touch?: ResponsiveElementTagName;
+  tablet?: ResponsiveElementTagName;
+  desktop?: ResponsiveElementTagName;
+  widescreen?: ResponsiveElementTagName;
+  fullhd?: ResponsiveElementTagName;
   className?: string;
 };
 
-const ResponsiveElement = ({
-  desktop,
-  touch,
-  children,
-  className,
-}: ResponsiveElementInfo) => {
-  const Desktop = desktop as keyof JSX.IntrinsicElements;
-  const Touch = touch as keyof JSX.IntrinsicElements;
+function ResponsiveElement(props: ResponsiveElementInfo): JSX.Element {
+  const { children, className, ...sizeTags } = props;
+
+  if (Object.keys(sizeTags).length < 2)
+    throw new Error("At least two sizes must be given.");
+
+  // https://bulma.io/documentation/helpers/visibility-helpers/#hide
+  const hiddenClasses = {
+    mobile: "is-hidden-tablet",
+    tabletOnly: "is-hidden-mobile is-hidden-desktop",
+    desktopOnly: "is-hidden-touch is-hidden-widescreen",
+    widescreenOnly: "is-hidden-touch is-hidden-desktop-only is-hidden-fullhd",
+    touch: "is-hidden-desktop",
+    tablet: "is-hidden-mobile",
+    desktop: "is-hidden-touch",
+    widescreen: "is-hidden-touch is-hidden-desktop-only",
+    fullhd: "is-hidden-touch is-hidden-desktop-only is-hidden-widescreen-only",
+  };
+
   return (
     <>
-      <Desktop className={classnames("is-hidden-touch", className || "")}>
-        {children}
-      </Desktop>
-      <Touch className={classnames("is-hidden-desktop", className || "")}>
-        {children}
-      </Touch>
+      {Object.keys(sizeTags).map((size: string, i: number) => {
+        const Tag = sizeTags[size] as keyof JSX.IntrinsicElements;
+        const classes = classnames(hiddenClasses[size], className);
+        return (
+          <Tag className={classes} key={i}>
+            {children}
+          </Tag>
+        );
+      })}
     </>
   );
-};
+}
 
 export default ResponsiveElement;

--- a/src/components/responsive-element.tsx
+++ b/src/components/responsive-element.tsx
@@ -26,15 +26,15 @@ const HIDDEN_CLASSES = {
 };
 
 const ResponsiveElement = (props: ResponsiveElementInfo): JSX.Element => {
-  const { children, className, ...sizeTags } = props;
+  const { children, className, tagNames } = props;
 
-  if (Object.keys(sizeTags).length < 2)
+  if (Object.keys(tagNames).length < 2)
     throw new Error("At least two sizes must be given.");
 
   return (
     <>
-      {Object.keys(sizeTags).map((size: string, i: number) => {
-        const Tag = sizeTags[size] as keyof JSX.IntrinsicElements;
+      {Object.keys(tagNames).map((size: string, i: number) => {
+        const Tag = tagNames[size] as keyof JSX.IntrinsicElements;
         const classes = classnames(HIDDEN_CLASSES[size], className);
         return (
           <Tag className={classes} key={i}>

--- a/src/components/responsive-element.tsx
+++ b/src/components/responsive-element.tsx
@@ -17,7 +17,7 @@ type ResponsiveElementInfo = {
   className?: string;
 };
 
-function ResponsiveElement(props: ResponsiveElementInfo): JSX.Element {
+const ResponsiveElement = (props: ResponsiveElementInfo): JSX.Element => {
   const { children, className, ...sizeTags } = props;
 
   if (Object.keys(sizeTags).length < 2)
@@ -49,6 +49,6 @@ function ResponsiveElement(props: ResponsiveElementInfo): JSX.Element {
       })}
     </>
   );
-}
+};
 
 export default ResponsiveElement;

--- a/src/components/responsive-element.tsx
+++ b/src/components/responsive-element.tsx
@@ -5,16 +5,24 @@ type ResponsiveElementTagName = "h1" | "h2" | "h3" | "h4" | "p";
 
 type ResponsiveElementInfo = {
   children: React.ReactNode;
-  mobile?: ResponsiveElementTagName;
-  tabletOnly?: ResponsiveElementTagName;
-  desktopOnly?: ResponsiveElementTagName;
-  widescreenOnly?: ResponsiveElementTagName;
-  touch?: ResponsiveElementTagName;
-  tablet?: ResponsiveElementTagName;
-  desktop?: ResponsiveElementTagName;
-  widescreen?: ResponsiveElementTagName;
-  fullhd?: ResponsiveElementTagName;
+  tagNames:
+    | { mobile: ResponsiveElementTagName; tablet: ResponsiveElementTagName }
+    | { touch: ResponsiveElementTagName; desktop: ResponsiveElementTagName }
+    | {
+        mobile: ResponsiveElementTagName;
+        tabletOnly: ResponsiveElementTagName;
+        desktop: ResponsiveElementTagName;
+      };
   className?: string;
+};
+
+// https://bulma.io/documentation/helpers/visibility-helpers/#hide
+const HIDDEN_CLASSES = {
+  mobile: "is-hidden-tablet",
+  touch: "is-hidden-desktop",
+  tablet: "is-hidden-mobile",
+  tabletOnly: "is-hidden-mobile is-hidden-desktop",
+  desktop: "is-hidden-touch",
 };
 
 const ResponsiveElement = (props: ResponsiveElementInfo): JSX.Element => {
@@ -23,24 +31,11 @@ const ResponsiveElement = (props: ResponsiveElementInfo): JSX.Element => {
   if (Object.keys(sizeTags).length < 2)
     throw new Error("At least two sizes must be given.");
 
-  // https://bulma.io/documentation/helpers/visibility-helpers/#hide
-  const hiddenClasses = {
-    mobile: "is-hidden-tablet",
-    tabletOnly: "is-hidden-mobile is-hidden-desktop",
-    desktopOnly: "is-hidden-touch is-hidden-widescreen",
-    widescreenOnly: "is-hidden-touch is-hidden-desktop-only is-hidden-fullhd",
-    touch: "is-hidden-desktop",
-    tablet: "is-hidden-mobile",
-    desktop: "is-hidden-touch",
-    widescreen: "is-hidden-touch is-hidden-desktop-only",
-    fullhd: "is-hidden-touch is-hidden-desktop-only is-hidden-widescreen-only",
-  };
-
   return (
     <>
       {Object.keys(sizeTags).map((size: string, i: number) => {
         const Tag = sizeTags[size] as keyof JSX.IntrinsicElements;
-        const classes = classnames(hiddenClasses[size], className);
+        const classes = classnames(HIDDEN_CLASSES[size], className);
         return (
           <Tag className={classes} key={i}>
             {children}

--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -176,7 +176,10 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                     to={`/learn/${props.content.learningCenterPreviewArticles[0].slug}`}
                     className="jf-link-article"
                   >
-                    <ResponsiveElement className="mb-6" desktop="h2" touch="h3">
+                    <ResponsiveElement
+                      tagNames={{ desktop: "h2", touch: "h3" }}
+                      className="mb-6"
+                    >
                       {props.content.learningCenterPreviewArticles[0].title}
                     </ResponsiveElement>
                   </Link>
@@ -255,8 +258,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
             <h1 className="mb-6">{props.content.partnershipsSectionTitle}</h1>
             <div className="has-background-success p-8 p-6-mobile is-flex-grow-1 is-flex is-flex-direction-column">
               <ResponsiveElement
-                desktop="h2"
-                touch="h3"
+                tagNames={{ desktop: "h2", touch: "h3" }}
                 className="py-5 pt-0-mobile mb-8"
               >
                 {props.content.partnershipsSectionSubtitle}
@@ -273,8 +275,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
             <h1 className="mb-6">{props.content.policySectionTitle}</h1>
             <div className="has-background-link p-8 p-6-mobile is-flex-grow-1 is-flex is-flex-direction-column">
               <ResponsiveElement
-                desktop="h2"
-                touch="h3"
+                tagNames={{ desktop: "h2", touch: "h3" }}
                 className="py-5 pt-0-mobile mb-8"
               >
                 {props.content.policySectionSubtitle}

--- a/src/pages/our-mission.en.tsx
+++ b/src/pages/our-mission.en.tsx
@@ -36,7 +36,7 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns has-background-warning is-multiline">
           <div className="column is-4 is-12-touch pt-13 pb-12 pt-6-touch px-6-touch pb-0-touch">
-          <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
+            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
               {props.content.visionTitle}
             </ResponsiveElement>
           </div>
@@ -57,7 +57,7 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns is-multiline">
           <div className="column is-4 is-12-touch pt-13 pb-12 pt-6-touch px-6-touch pb-0-touch">
-          <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
+            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
               {props.content.impactTitle}
             </ResponsiveElement>
           </div>
@@ -72,13 +72,12 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
                       to={latestReport.link}
                       className="jf-link-article"
                     >
-                    <ResponsiveElement
-                      tagNames={{ desktop: "h2", touch: "h1" }}
-                    >
-                      {latestReport.title}
+                      <ResponsiveElement
+                        tagNames={{ desktop: "h2", touch: "h1" }}
+                      >
+                        {latestReport.title}
                       </ResponsiveElement>
                     </LocaleLink>
-
                   </div>
                   <div className="column is-5">
                     <h3 className="has-text-weight-normal mb-3">
@@ -102,9 +101,10 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
               {pastReports.map((report: any, i: number) => (
                 <div className="column is-paddingless is-4 mb-7" key={i}>
                   <LocaleLink to={report.link} className="jf-link-article">
-                    <ResponsiveElement 
-                                        tagNames={{ desktop: "h4", touch: "h3" }}
-                                        className="mb-3" >
+                    <ResponsiveElement
+                      tagNames={{ desktop: "h4", touch: "h3" }}
+                      className="mb-3"
+                    >
                       {report.title}
                     </ResponsiveElement>
                   </LocaleLink>
@@ -117,7 +117,7 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns has-background-info is-multiline">
           <div className="column is-4 is-12-touch pt-13 pb-12 p-6-touch">
-          <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
+            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
               {props.content.valuesTitle}
             </ResponsiveElement>
           </div>

--- a/src/pages/our-mission.en.tsx
+++ b/src/pages/our-mission.en.tsx
@@ -22,7 +22,7 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns">
           <div className="column is-4 pt-13 pb-12 p-6-mobile">
-            <ResponsiveElement desktop="h2" touch="h1">
+            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
               {props.content.missionTitle}
             </ResponsiveElement>
           </div>
@@ -36,13 +36,13 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns has-background-warning">
           <div className="column is-4 pt-13 pb-12 pt-6-mobile px-6-mobile pb-0-mobile">
-            <ResponsiveElement desktop="h2" touch="h1">
+            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
               {props.content.visionTitle}
             </ResponsiveElement>
           </div>
           <div className="column is-1 is-hidden-mobile" />
           <div className="column is-7 pt-13 pb-12 p-6-mobile jf-text-block-with-spacing">
-            <ResponsiveElement desktop="h3" touch="h2">
+            <ResponsiveElement tagNames={{ desktop: "h3", touch: "h2" }}>
               {props.content.visionSubtitle}
             </ResponsiveElement>
             {documentToReactComponents(props.content.visionContent.json, {
@@ -57,7 +57,7 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns">
           <div className="column is-4 pt-13 pb-12 pt-6-mobile px-6-mobile pb-0-mobile">
-            <ResponsiveElement desktop="h2" touch="h1">
+            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
               {props.content.impactTitle}
             </ResponsiveElement>
           </div>
@@ -70,7 +70,9 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
               <div className="column is-9 has-background-black has-text-white">
                 <div className="columns is-paddingless">
                   <div className="column is-7">
-                    <ResponsiveElement desktop="h2" touch="h1">
+                    <ResponsiveElement
+                      tagNames={{ desktop: "h2", touch: "h1" }}
+                    >
                       {latestReport.title}
                     </ResponsiveElement>
                   </div>
@@ -85,16 +87,18 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
               </div>
             </div>
             <ResponsiveElement
+              tagNames={{ desktop: "h3", touch: "h2" }}
               className="mt-10 mb-7 my-6-mobile"
-              desktop="h3"
-              touch="h2"
             >
               {props.content.pastReportsSubtitle}
             </ResponsiveElement>
             <div className="columns is-paddingless is-multiline">
               {pastReports.map((report: any, i: number) => (
                 <div className="column is-paddingless is-4 mb-7" key={i}>
-                  <ResponsiveElement className="mb-3" desktop="h4" touch="h3">
+                  <ResponsiveElement
+                    tagNames={{ desktop: "h4", touch: "h3" }}
+                    className="mb-3"
+                  >
                     {report.title}
                   </ResponsiveElement>
                   <ReadMoreLink url={report.link} />
@@ -106,7 +110,7 @@ export const MissionPageScaffolding = (props: ContentfulContent) => {
 
         <div className="columns has-background-info">
           <div className="column is-4 pt-13 pb-12 p-6-mobile">
-            <ResponsiveElement desktop="h2" touch="h1">
+            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
               {props.content.valuesTitle}
             </ResponsiveElement>
           </div>

--- a/src/pages/partners.en.tsx
+++ b/src/pages/partners.en.tsx
@@ -154,7 +154,7 @@ const PartnershipCaseStudy: React.FC<PartnershipCaseStudyDetails> = ({
       <div className="eyebrow is-large mb-3">
         <Trans>Partnership case study</Trans>
       </div>
-      <ResponsiveElement desktop="h2" touch="h1">
+      <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
         {title}
       </ResponsiveElement>
     </div>
@@ -176,7 +176,7 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
 
       <div className="columns">
         <div className="column is-4 pt-13 pb-12 p-6-mobile">
-          <ResponsiveElement desktop="h2" touch="h1">
+          <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
             {props.content.title}
           </ResponsiveElement>
         </div>
@@ -254,7 +254,7 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
         <div className="column pt-13 pb-12 p-6-mobile">
           <div className="columns is-paddingless">
             <div className="column is-5 mb-12 mb-0-mobile px-0-mobile pb-4-mobile">
-              <ResponsiveElement desktop="h2" touch="h1">
+              <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
                 {props.content.fundersTitle}
               </ResponsiveElement>
             </div>

--- a/src/pages/partners.en.tsx
+++ b/src/pages/partners.en.tsx
@@ -176,7 +176,7 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
 
       <div className="columns is-multiline">
         <div className="column is-4 is-12-touch pt-13 pb-12 p-6-touch">
-        <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
+          <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
             {props.content.title}
           </ResponsiveElement>
         </div>
@@ -251,10 +251,10 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
       </div>
 
       <div className="columns">
-      <div className="column pt-13 pb-12 p-6-touch">
+        <div className="column pt-13 pb-12 p-6-touch">
           <div className="columns is-multiline is-paddingless">
             <div className="column is-5 is-12-touch mb-12 mb-0-touch px-0-touch pb-4-touch">
-            <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
+              <ResponsiveElement tagNames={{ desktop: "h2", touch: "h1" }}>
                 {props.content.fundersTitle}
               </ResponsiveElement>
             </div>

--- a/src/pages/press.en.tsx
+++ b/src/pages/press.en.tsx
@@ -66,7 +66,10 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
                   href={press.hyperlink}
                   className="jf-link-article"
                 >
-                  <ResponsiveElement desktop="h2" touch="h3" className="mb-6">
+                  <ResponsiveElement
+                    tagNames={{ desktop: "h2", touch: "h3" }}
+                    className="mb-6"
+                  >
                     {press.linkText}
                   </ResponsiveElement>
                 </OutboundLink>
@@ -80,7 +83,10 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
             </div>
           ))}
           <div className="column is-8 has-background-black has-text-white py-10 px-7 mt-6 mb-12 mx-5-mobile">
-            <ResponsiveElement desktop="h2" touch="h3" className="mb-6">
+            <ResponsiveElement
+              tagNames={{ desktop: "h2", touch: "h3" }}
+              className="mb-6"
+            >
               {documentToReactComponents(
                 props.content.pressInquiryBanner.content.json
               )}

--- a/src/pages/press.en.tsx
+++ b/src/pages/press.en.tsx
@@ -83,11 +83,11 @@ export const PressPageScaffolding = (props: ContentfulContent) => {
             </div>
           ))}
           <div className="column is-8 is-12-touch has-background-black has-text-white py-10 px-7 mt-6 mb-12 mx-5-touch">
-          <ResponsiveElement
+            <ResponsiveElement
               tagNames={{ desktop: "h2", touch: "h3" }}
               className="mb-6"
             >
-                            {documentToReactComponents(
+              {documentToReactComponents(
                 props.content.pressInquiryBanner.content.json
               )}
             </ResponsiveElement>

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -49,8 +49,7 @@ const ReportCard: React.FC<ReportCardInfo> = (props) => (
       </div>
       <div className="column is-6 px-9 px-6-mobile pt-8 pb-11 py-7-mobile is-flex is-flex-direction-column">
         <ResponsiveElement
-          desktop="h2"
-          touch="h3"
+          tagNames={{ desktop: "h2", touch: "h3" }}
           children={props.reportTitle}
           className="pb-6"
         />
@@ -82,8 +81,7 @@ export const PolicyPageScaffolding = (props: ContentfulContent) => {
         <div className="columns pt-13 pb-11 p-6-mobile">
           <div className="column is-4 py-0 p-0-mobile">
             <ResponsiveElement
-              desktop="h2"
-              touch="h1"
+              tagNames={{ desktop: "h2", touch: "h1" }}
               children={props.content.approachTitle}
             />
           </div>
@@ -101,8 +99,7 @@ export const PolicyPageScaffolding = (props: ContentfulContent) => {
         >
           <div className="column is-3">
             <ResponsiveElement
-              desktop="h2"
-              touch="h1"
+              tagNames={{ desktop: "h2", touch: "h1" }}
               children={props.content.reportsTitle}
             />
           </div>

--- a/src/pages/team.en.tsx
+++ b/src/pages/team.en.tsx
@@ -83,8 +83,7 @@ export const TeamPageScaffolding = (props: ContentfulContent) => (
         <div className="columns">
           <div className="column">
             <ResponsiveElement
-              desktop="h2"
-              touch="h1"
+              tagNames={{ desktop: "h2", touch: "h1" }}
               className="jf-team-title"
             >
               {props.content.otherContributorsTitle}


### PR DESCRIPTION
This PR changes the `ResponsiveElement` component to add arguments for all of the Bulma responsive sizes, instead of just `desktop` and `touch`.