### PR TITLE
Learning Center Article text style QA

### DIFF
--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -97,8 +97,9 @@ const LearningArticle = (props: Props) => {
       id="navmenu"
       className={classnames("menu", props && props.styleClass)}
     >
-      <p className="p-4 is-uppercase has-text-weight-bold">
-        <Trans>Contents</Trans>
+      <div className="is-divider is-hidden-tablet mt-0" />
+      <p className="p-4 px-0-mobile is-uppercase has-text-weight-bold">
+        <Trans>Jump to</Trans>
       </p>
       <ul className="menu-list">
         {content.articleSections.map((articleSection: any, i: number) =>
@@ -111,7 +112,7 @@ const LearningArticle = (props: Props) => {
                 smooth={true}
                 offset={-100}
                 duration={500}
-                className="p-4 has-text-black no-underline"
+                className="p-4 px-0-mobile has-text-black"
               >
                 {articleSection.title}
               </ScrollLink>
@@ -121,6 +122,7 @@ const LearningArticle = (props: Props) => {
           )
         )}
       </ul>
+      <div className="is-divider is-hidden-tablet mb-0" />
     </aside>
   );
 

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -172,7 +172,7 @@ const LearningArticle = (props: Props) => {
               )}
             </p>
 
-            <div className="columns is-paddingless has-background-light">
+            <div className="jf-summary-box columns is-paddingless has-background-light">
               <div className="column is-6 p-5">
                 <h4>
                   <Trans>Summary</Trans>

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -55,7 +55,9 @@ function renderSection(articleSection: any, i: number): JSX.Element {
         </div>
       ) : (
         <div>
-          <h3 className="my-6 my-5-mobile">{widont(articleSection.title)}</h3>
+          <h3 className="has-text-weight-semibold my-6 mb-5-mobile mt-7-mobile">
+            {widont(articleSection.title)}
+          </h3>
           {documentToReactComponents(articleSection.content.json, {
             renderNode: {
               [BLOCKS.PARAGRAPH]: (node, children) => (

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -179,7 +179,7 @@ const LearningArticle = (props: Props) => {
                 <h4>
                   <Trans>What can JustFix do?</Trans>
                 </h4>
-                <p>{documentToReactComponents(content.whatCanIDo.json)}</p>
+                {documentToReactComponents(content.whatCanIDo.json)}
               </div>
             </div>
 

--- a/src/components/learning-center/article-template.tsx
+++ b/src/components/learning-center/article-template.tsx
@@ -166,9 +166,12 @@ const LearningArticle = (props: Props) => {
               <Trans>Published</Trans> {content.dateUpdated}
             </div>
 
-            <p className="has-text-dark mb-6 mb-8-mobile">
+            <p className="title is-4 has-text-dark mb-6 mb-8-mobile">
               {content.author || (
-                <Trans>This article was written by the JustFix team</Trans>
+                <Trans>
+                  This article was written by the team of housing experts at
+                  JustFix
+                </Trans>
               )}
             </p>
 

--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -73,6 +73,11 @@
 }
 .jf-article-page {
   .jf-summary-box {
+    h4 {
+      @include mobile {
+        font-weight: 600;
+      }
+    }
     p {
       line-height: 120%;
     }

--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -72,6 +72,11 @@
   }
 }
 .jf-article-page {
+  .jf-summary-box {
+    p {
+      line-height: 120%;
+    }
+  }
   .article-section ul {
     list-style: square;
   }

--- a/src/styles/learn.scss
+++ b/src/styles/learn.scss
@@ -82,9 +82,18 @@
       top: $spacing-08;
     }
 
-    li a:hover {
-      text-decoration: none;
-      background-color: $light;
+    li a {
+      @include desktop {
+        text-decoration: none;
+      }
+
+      &:hover {
+        @include desktop {
+          text-decoration: underline;
+        }
+
+        background-color: $light;
+      }
     }
   }
 


### PR DESCRIPTION
[fixed nested `<p>` tags console error](https://github.com/JustFixNYC/justfix-website/commit/89039c23af9ec0e821622c1984666e3915cec5ce)

[sc-10643] - [mobile section titles semi-bold & more margin top](https://github.com/JustFixNYC/justfix-website/commit/a1fcb0fd77d1e25a023c9d5beb017938819acd12) (turns out the desktop weight for H3 is already semibold, so it's ok that this class isn't mobile-specific) 
<img width="376" alt="image" src="https://user-images.githubusercontent.com/16906516/184247235-b81bbb52-360f-4b0a-84c3-77adf114c084.png">

[sc-10648] - [contents/jump-to sticky section](https://github.com/JustFixNYC/justfix-website/pull/317/commits/8f438765066caedb34be2a35439e494fb406f943) 
  - change section title from Contents to "Jump to" 
  - underline links to clarify that this is navigation (on mobile) 
  - underline links on hover to clarify that this is navigation (on desktop) 
  - make column full width instead of inset (on mobile) 
  - add top and bottom rules (on mobile)

![image](https://user-images.githubusercontent.com/16906516/184251811-242ba248-337d-42a7-b931-7725d9385390.png)
![image](https://user-images.githubusercontent.com/16906516/184251833-ca2915b0-b58f-43fa-9af3-d1407e7c3bf6.png)

[sc-10657] - [increase line height for Summary box](https://github.com/JustFixNYC/justfix-website/pull/317/commits/5f693c92ff51ad3e3c4f97b6e47b20280cab4d7d)
<img width="813" alt="image" src="https://user-images.githubusercontent.com/16906516/184253378-de947108-ffdb-47f7-ad17-cc7de13d8666.png">

[sc-10681] - [make summary box titles semi-bold on mobile](https://github.com/JustFixNYC/justfix-website/pull/317/commits/2bd28ee7695d780089674a7e419597431fa3de4f)
<img width="376" alt="image" src="https://user-images.githubusercontent.com/16906516/184253868-b5c80a7c-d29f-47a1-8fcc-66728e60d67b.png">

[sc-10645] - [author note larger on desktop, copy change](https://github.com/JustFixNYC/justfix-website/pull/317/commits/82c5ab0543af6ecc3ebf0289e92c23139a932f7d)
<img width="713" alt="image" src="https://user-images.githubusercontent.com/16906516/184254364-7f47f846-3408-49a3-96c6-e43581ca9879.png">
