### PR TITLE
article card titles semi-bold on mobile

### DIFF
--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -168,7 +168,7 @@ export const LearningPageScaffolding = (props: ContentfulContent) => {
     <Layout metadata={props.content.metadata}>
       <div id="learning-center" className="learning-center-page">
         <div className="columns is-centered is-multiline pt-12 pt-7-touch pb-10">
-          <div className="column is-8 is-12-touch pb-0 mb-12">
+          <div className="column is-8 is-12-touch pb-0 mb-12 mb-9-mobile">
             <span className="eyebrow is-uppercase">
               <Trans>Learning Center</Trans>
             </span>

--- a/src/pages/learn.en.tsx
+++ b/src/pages/learn.en.tsx
@@ -120,7 +120,9 @@ export const ArticlePreviewCard = (props: ArticlePreviewInfo) => {
           </div>
           <div className="mb-6 mb-3-touch">
             <LocaleLink className={"jf-link-article"} to={articleUrl}>
-              <h3 className="mb-6 mb-3-touch">{props.title}</h3>
+              <h3 className="has-text-weight-semibold mb-6 mb-3-touch">
+                {props.title}
+              </h3>
             </LocaleLink>
             <span className="is-hidden-touch eyebrow is-small">
               <Trans>Updated</Trans> {formatDate(props.dateUpdated, locale)}


### PR DESCRIPTION
[sc-10655] - [article card titles semi-bold on mobile](https://github.com/JustFixNYC/justfix-website/commit/995895a9fa94c6a7706ecab01300c6d7f71765d0)

<img width="377" alt="image" src="https://user-images.githubusercontent.com/16906516/184255790-d242140c-e014-476e-b49b-248cd22d8041.png">

[sc-10683] - [reduce spacing below searchbar on mobile](https://github.com/JustFixNYC/justfix-website/pull/318/commits/6641bb2623b25be6be2f43a4af2fb9ce287f7ae2)

<img width="378" alt="image" src="https://user-images.githubusercontent.com/16906516/184256123-d886be30-696f-46c4-b473-c3c58e70519c.png">


