### PR TITLE
misc QA spacing fixes

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -107,7 +107,7 @@ export const ProductList: React.FC<ProductListInfo> = (props) => (
     className="has-background-link has-text-black pb-12 pb-6-touch"
   >
     <div className="columns is-multiline">
-      <div className="column is-12 pt-10 pt-7-touch pb-9">
+      <div className="column is-12 pt-10 pt-7-touch pb-9 pb-0-touch">
         <h1>{props.productSectionTitle}</h1>
       </div>
       {props.homePageProductBlocks.map((product: any, i: number) => (

--- a/src/pages/reports.en.tsx
+++ b/src/pages/reports.en.tsx
@@ -38,7 +38,7 @@ type ReportCardInfo = {
 };
 
 const ReportCard: React.FC<ReportCardInfo> = (props) => (
-  <div className="mt-6 mb-9 mt-0-touch">
+  <div className="mb-10">
     <div className="jf-report-card columns is-paddingless is-multiline has-background-white">
       <div className="column is-6 is-12-touch is-paddingless">
         <Img


### PR DESCRIPTION
[sc-10620] - [align reports title with card image](https://github.com/JustFixNYC/justfix-website/commit/e02c34ee07fca5ff6b9d20e7c822772dc87c04e8)

<img width="452" alt="image" src="https://user-images.githubusercontent.com/16906516/184262890-efed84c7-16cd-4166-9d3c-5ab9e152eaeb.png">

[sc-10677] - [reduce space below tools title on mobile](https://github.com/JustFixNYC/justfix-website/pull/321/commits/2ffd492b95729570c1d75196703b9bb5662b5bfa)

<img width="386" alt="image" src="https://user-images.githubusercontent.com/16906516/184279910-b6847f45-0ea9-4677-a988-c873de5087c1.png">
