### PR TITLE
hover underline on footer page links

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -42,7 +42,7 @@ const FooterLink: React.FC<{ link: LinkWithLabel }> = ({ link }) =>
       <p className="title is-4 has-text-white py-3-mobile">{link[1]}</p>
     </Link>
   ) : (
-    <OutboundLink className="no-underline" href={link[0]}>
+    <OutboundLink className="jf-footer-page-link no-underline" href={link[0]}>
       <p className="title is-4 has-text-white py-3-mobile">{link[1]}</p>
     </OutboundLink>
   );

--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -16,6 +16,11 @@
 
   .jf-footer-page-link {
     p {
+      &:hover,
+      &:focus,
+      &:active {
+        text-decoration: underline;
+      }
       @include mobile {
         @include mobile-h3;
       }


### PR DESCRIPTION
add underline on hover for footer page link, same as for the header menu

[sc-10665]

![image](https://user-images.githubusercontent.com/16906516/184900771-39d3460b-3eca-4422-bd55-348be364ebdf.png)
