### PR TITLE
change buttons/links on tool cards

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -32,6 +32,7 @@ type ProductCardInfo = {
     title: string;
     link: string;
   };
+  smsText?: string;
   /**
    * Whether or not the product card will use condensed spacing styling
    */
@@ -40,9 +41,19 @@ type ProductCardInfo = {
 
 const Dot = () => <span className="mx-3">·</span>;
 
+const formatPhoneNumber = (phone: string): string | null => {
+  const match = phone.match(/^(\d{3})(\d{3})(\d{4})$/);
+  if (!match) return null;
+  return `(${match[1]}) ${match[2]}-${match[3]}`;
+};
+
 export const ProductCard: React.FC<ProductCardInfo> = (props) => {
   const { link } = props.button;
-  const toolLink = link + (link.startsWith("sms") ? "" : PRODUCT_CTA_UTM_CODE);
+  const isSmsTool = link.startsWith("sms");
+  const toolLink = link + (isSmsTool ? "" : PRODUCT_CTA_UTM_CODE);
+  const phoneNumber = isSmsTool
+    ? formatPhoneNumber(link.substring(6, 16))
+    : null;
 
   return (
     <div
@@ -77,9 +88,21 @@ export const ProductCard: React.FC<ProductCardInfo> = (props) => {
               ])}
           </div>
 
-          <OutboundLink href={toolLink} className="button is-primary">
+          <OutboundLink
+            href={toolLink}
+            className={classnames(
+              "button is-primary",
+              isSmsTool && "is-hidden-tablet"
+            )}
+          >
             {props.button.title}
           </OutboundLink>
+          {isSmsTool && (
+            <p className="title is-4 has-text-weight-bold is-hidden-mobile">
+              Text <span className="is-uppercase">{props.smsText}</span> to{" "}
+              <span>{phoneNumber}</span>
+            </p>
+          )}
         </div>
       </div>
     </div>
@@ -338,6 +361,7 @@ export const LandingPageFragment = graphql`
           title
           link
         }
+        smsText
         location
         language
       }

--- a/src/pages/tools.en.tsx
+++ b/src/pages/tools.en.tsx
@@ -55,7 +55,7 @@ export const ToolsPageScaffolding = (props: ContentfulContent) => {
             <div className="title is-4 mb-5">
               {documentToReactComponents(tool.toolDescription.json)}
             </div>
-            <ReadMoreLink url={tool.readMoreLink} />
+            {tool.readMoreLink && <ReadMoreLink url={tool.readMoreLink} />}
             <div className="is-divider is-hidden-tablet mt-10" />
           </div>
         ))}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -32,6 +32,11 @@
 @import "_design-system.scss";
 
 .home-page {
+  .jf-card {
+    p span {
+      white-space: nowrap;
+    }
+  }
   .jf-learning-center-preview {
     .jf-lc-featured {
       @include desktop {


### PR DESCRIPTION
[sc-10483] - [make past tool read-more link optional](https://github.com/JustFixNYC/justfix-website/commit/addeaed51be61585e550bc43609b0c24f58a8e8a) (contentful model changed accordingly)

![image](https://user-images.githubusercontent.com/16906516/185227198-b8b72b07-71a0-4842-a542-6ab6eda89224.png)

[sc-10669] - [display sms msg/number not button on tablet+](https://github.com/JustFixNYC/justfix-website/pull/327/commits/c5714cd23e35f5c7a1e110deabab1b46300344a5)

![Clipboard 2022-18-08 at 4 18 46 PM](https://user-images.githubusercontent.com/16906516/185491698-a3d41b00-5ed0-4bd5-acae-74b6ce033c29.png)

