### PR TITLE
add sms text prompt for tools page

### DIFF
--- a/src/pages/tools.en.tsx
+++ b/src/pages/tools.en.tsx
@@ -110,6 +110,7 @@ export const ToolsPageFragment = graphql`
           title
           link
         }
+        smsText
         location
         language
       }


### PR DESCRIPTION
This PR fixes an issue that left out the sms text prompt for product cards on the tools page. The new `smsText` field was missing from the graphql query on the tools page. 