### PR TITLE
add fb domain code to html pre locale redirect

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -20,7 +20,7 @@ const SITE_TITLE_SUFFIX = " | JustFix";
 const TWITTER_HANDLE = "@JustFixOrg";
 const SITE_MAIN_URL = "https://www.justfix.org";
 const FB_APP_ID = "247990609143668";
-const FB_PIXEL_CODE = "o8wthqxkcblw3olfnavr7bi1x0bv5l";
+export const FB_PIXEL_CODE = "o8wthqxkcblw3olfnavr7bi1x0bv5l";
 
 // All our supported locales.
 type StringLocales = "es" | "en";

--- a/src/components/locale-redirect.tsx
+++ b/src/components/locale-redirect.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useEffect } from "react";
 import { navigate } from "gatsby";
 import localeConfig from "../util/locale-config.json";
-
+import { FB_PIXEL_CODE } from "../components/layout";
 import "../styles/locale-redirect.scss";
 
 // This component redirects users to a localized version of the given route
@@ -50,6 +50,10 @@ const LocaleRedirectPage = (props: Props) => {
 
   return (
     <html lang="en">
+      <head>
+        {/* FB process is not completing the locale redirect so the code needs to be here */}
+        <meta name="facebook-domain-verification" content={FB_PIXEL_CODE} />
+      </head>
       <noscript>
         <meta
           httpEquiv="refresh"


### PR DESCRIPTION
We need to verify our domain with Facebook/pixel but are having a problem that their [debugger tool](https://developers.facebook.com/tools/debug) that scrape the page is not finding our meta tag. The support hasn't been helpful at all, so I've been guessing at the issue. 

After comparing the debug results of orgsite to latenants.justfix.org it seems like the issue is that the scraper is not following the re-direct from `justfix.org` to `justfix.org/en` and so it gets stuck on [this page](https://github.com/JustFixNYC/justfix-website/blob/82ff60d4ca72383771f4082c9773f9250ee89750/src/components/locale-redirect.tsx#L52-L70) and never gets to the full page that has all our meta tags. 

latenants.justfix.org
<img width="330" alt="image" src="https://user-images.githubusercontent.com/16906516/192861989-a479f3d5-5781-40d0-9e68-da8f1aa19884.png">

justfix.org
<img width="284" alt="image" src="https://user-images.githubusercontent.com/16906516/192862031-1fc74c40-9197-4c4b-a8c6-f4dc7220c603.png">

My first thought was that the problem was our use of `http-equiv="refresh"` to complete the redirect if javascript is not enabled. But I set up a demo site that uses the same method (and timing) and the facebook debugger follows that redirect.

austensen.github.io/redirect-test
<img width="496" alt="image" src="https://user-images.githubusercontent.com/16906516/192873363-228556b6-9407-45b6-949d-f90438701cc4.png">

Since we aren't otherwise having any problems with the redirect, I thought it might make sense to just add the FB meta tag on this pre-redirect page as well and see if that works to get the verification done. What do you think @shakao? 