### PR TITLE
add donate button to footer and contact-us

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -78,7 +78,7 @@ const FooterLinksList: React.FC<{ links: LinkWithLabel[] }> = ({ links }) => {
 const Footer = () => (
   <div className="jf-footer has-background-black has-text-white py-7">
     <div className="columns is-multiline">
-      <div className="column is-4 is-12-touch pt-9 pb-7-touch">
+      <div className="column is-4 is-12-touch pt-9 mt-2 pb-7-touch">
         <FooterLanguageToggle />
       </div>
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -59,11 +59,11 @@ const FooterLink: React.FC<{ link: LinkWithLabel }> = ({ link }) =>
 
 const FooterLinksList: React.FC<{ links: LinkWithLabel[] }> = ({ links }) => {
   return (
-    <div className="columns is-paddingless is-hidden-touch ml-0">
+    <div className="columns is-paddingless ml-0">
       {links.map((link, i) => {
         if (i % 3 === 0) {
           return (
-            <div className="column is-4 is-paddingless mx-0" key={i}>
+            <div className="column is-4 py-0 mx-0" key={i}>
               <FooterLink link={link} />
               {!!links[i + 1] && <FooterLink link={links[i + 1]} />}
               {!!links[i + 2] && <FooterLink link={links[i + 2]} />}
@@ -78,12 +78,23 @@ const FooterLinksList: React.FC<{ links: LinkWithLabel[] }> = ({ links }) => {
 const Footer = () => (
   <div className="jf-footer has-background-black has-text-white py-7">
     <div className="columns is-multiline">
-      <div className="column is-8 is-12-touch pt-9">
+      <div className="column is-4 is-12-touch pt-9 pb-7-touch">
         <FooterLanguageToggle />
-        <FooterLinksList links={SITE_LINKS} />
       </div>
 
-      <div className="column is-4 is-12-touch">
+      <div className="column is-4 is-12-touch py-7-touch">
+        <h4 className="mb-2">
+          <Trans>Support JustFix</Trans>
+        </h4>
+        <OutboundLink
+          href="https://donorbox.org/donate-to-justfix-nyc"
+          className="button is-primary"
+        >
+          <Trans>Donate today</Trans>
+        </OutboundLink>
+      </div>
+
+      <div className="column is-4 is-12-touch py-7-touch">
         <h4 className="mb-2">
           <Trans>Join our mailing list!</Trans>
         </h4>
@@ -137,11 +148,18 @@ const Footer = () => (
             style={{ height: 40, width: 40 }}
           />
         </div>
-        <div className="mt-8 is-hidden-desktop">
-          {SITE_LINKS.map((link, i) => (
-            <FooterLink link={link} key={i} />
-          ))}
-        </div>
+      </div>
+    </div>
+
+    <div className="columns">
+      <div className="column is-12 pb-0">
+        <div className="is-divider is-light" />
+      </div>
+    </div>
+
+    <div className="columns">
+      <div className="column is-12 pb-0">
+        <FooterLinksList links={SITE_LINKS} />
       </div>
     </div>
 

--- a/src/pages/contact-us.en.tsx
+++ b/src/pages/contact-us.en.tsx
@@ -2,10 +2,10 @@ import React from "react";
 import { StaticQuery, graphql } from "gatsby";
 import { SocialIcon } from "react-social-icons";
 import { documentToReactComponents } from "@contentful/rich-text-react-renderer";
-
 import Layout from "../components/layout";
 import { ContentfulContent } from "./index.en";
 import Subscribe from "../components/subscribe";
+import { OutboundLink } from "../util/links";
 
 export const ContactPageScaffolding = (props: ContentfulContent) => (
   <Layout metadata={props.content.metadata}>
@@ -31,6 +31,22 @@ export const ContactPageScaffolding = (props: ContentfulContent) => (
               />
             ))}
           </div>
+        </div>
+      </div>
+      <div className="columns is-centered has-background-black has-text-white">
+        <div className="column is-12 py-11">
+          <h1>{props.content.donateTitle}</h1>
+          <div className="mt-5 mb-8">
+            <span className="title is-3 has-text-white">
+              {documentToReactComponents(props.content.donateCta.json)}
+            </span>
+          </div>
+          <OutboundLink
+            href={props.content.donateButton.link}
+            className="button is-primary"
+          >
+            {props.content.donateButton.title}
+          </OutboundLink>
         </div>
       </div>
       <div className="columns is-centered has-background-info">
@@ -70,6 +86,14 @@ export const ContactPageFragment = graphql`
       socialButtons {
         title
         url
+      }
+      donateTitle
+      donateCta {
+        json
+      }
+      donateButton {
+        title
+        link
       }
       mailingListTitle
       mailingListSubtitle


### PR DESCRIPTION
This PR adds a Donate button to the footer and donate section to the Contact Us page for our [DonorBox](https://donorbox.org/donate-to-justfix-nyc). 

The footer is reorganized to have three columns and the page links are moved down to their own section. On the contact us page the the new donate section content is added in contentful. 

<img width="1515" alt="image" src="https://user-images.githubusercontent.com/16906516/193285751-90ae164d-4b40-43da-b169-ac6382376970.png">
<img width="456" alt="image" src="https://user-images.githubusercontent.com/16906516/193282728-065e611e-12d1-48a0-b8e5-dd7b1b464d00.png">
<img width="1518" alt="image" src="https://user-images.githubusercontent.com/16906516/193282573-2babf96b-23a4-4938-ac3b-6915eb120801.png">


[sc-10963]