### PR TITLE
Add Github action to scan for learning center deadlinks

### DIFF
--- a/.github/deadlink.yml
+++ b/.github/deadlink.yml
@@ -1,0 +1,14 @@
+on:
+  schedule:
+  - cron: "0 5 * * 1"
+
+jobs:
+  find_dead_links:
+    runs-on: ubuntu-latest
+    name: Deadlink crawler
+    steps:
+      - name: Scan learning center
+        uses: JustFixNYC/deadlink-crawler@v1.0
+        with:
+          site-url: "https://www.justfix.org/en/learn"
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
adds a github action that runs every Monday at 5AM UTC (1AM ET) which will scan the learning center for deadlinks and create an issue in this repo with the discovered links. i figure we can adjust the frequency of the action after we see how many links it finds in a couple runs? maybe once a month would be enough.

the bulk of the action logic is here: https://github.com/JustFixNYC/deadlink-crawler/blob/main/index.js and it's pretty straightforward, we use a deadlink scanning tool to scan the orgsite, collect all broken links, and generate a markdown list. 

linkedin has known issues being scanned, and i was getting some false positives with netlify as well, so those are in the exclusions list

[sc-10979]