### PR TITLE
Scan for deadlinks on the first of each month

### DIFF
--- a/.github/workflows/deadlink.yml
+++ b/.github/workflows/deadlink.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-  - cron: "0 5 * * 1"
+  - cron: "0 5 1 * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
it won't necessarily be a weekday, once-a-week is definitely too frequent for deadlink scanning, so reducing it to once a month for now!

have also configured the slack bot to post a notification to the learning center channel whenever a scan is completed 

[sc-11166]