### PR TITLE
add default helmet to all redirect pages

### DIFF
--- a/src/components/locale-redirect.tsx
+++ b/src/components/locale-redirect.tsx
@@ -2,8 +2,13 @@ import React from "react";
 import { useEffect } from "react";
 import { navigate } from "gatsby";
 import localeConfig from "../util/locale-config.json";
-import { FB_PIXEL_CODE } from "../components/layout";
+import {
+  getDefaultContentForLocale,
+  HelmetWithDefault,
+} from "../components/layout";
 import "../styles/locale-redirect.scss";
+import { StaticQuery, graphql } from "gatsby";
+import ReactDOM from "react-dom/server";
 
 // This component redirects users to a localized version of the given route
 // based on their browser's preferred language
@@ -29,6 +34,15 @@ const getRedirectLanguage = (
   return lang;
 };
 
+const Noscript = (props: any) => {
+  // Contents of <noscript> gets lost when hydrating; this component fixes that
+  // https://github.com/facebook/react/issues/1252
+
+  const staticMarkup = ReactDOM.renderToStaticMarkup(props.children);
+
+  return <noscript dangerouslySetInnerHTML={{ __html: staticMarkup }} />;
+};
+
 type Props = {
   pageContext: {
     slug: string;
@@ -49,25 +63,53 @@ const LocaleRedirectPage = (props: Props) => {
   }, []);
 
   return (
-    <html lang="en">
-      <head>
-        {/* FB process is not completing the locale redirect so the code needs to be here */}
-        <meta name="facebook-domain-verification" content={FB_PIXEL_CODE} />
-      </head>
-      <noscript>
-        <meta
-          httpEquiv="refresh"
-          content={`3;url=${redirectURL}`}
-          data-react-helmet="false"
-        />
-      </noscript>
-      <body>
-        <p className="jf-redirect-message">
-          If you're not automatically redirected, please visit{" "}
-          <a href={redirectURL}>{redirectURL}</a>.
-        </p>
-      </body>
-    </html>
+    <StaticQuery
+      query={graphql`
+        query {
+          allContentfulHomePage {
+            nodes {
+              node_locale
+              metadata {
+                title
+                description
+                keywords {
+                  keywords
+                }
+                shareImage {
+                  file {
+                    url
+                  }
+                }
+              }
+            }
+          }
+        }
+      `}
+      render={(data) => (
+        <>
+          <HelmetWithDefault
+            defaultContent={getDefaultContentForLocale(
+              localeConfig.DEFAULT_LOCALE,
+              data.allContentfulHomePage.nodes
+            )}
+            locale={localeConfig.DEFAULT_LOCALE}
+          />
+          <Noscript>
+            <meta
+              httpEquiv="refresh"
+              content={`3;url=${redirectURL}`}
+              data-react-helmet="false"
+            />
+          </Noscript>
+          <div>
+            <p className="jf-redirect-message">
+              If you're not automatically redirected, please visit{" "}
+              <a href={redirectURL}>{redirectURL}</a>.
+            </p>
+          </div>
+        </>
+      )}
+    />
   );
 };
 


### PR DESCRIPTION
All URLs without a locale in the path first land at a page with redirect info for users without javascript enabled and automatically redirects others to the locale based on their headers. Previously we hadn't included all of the <head> contents on these pages, but that meant that if you shared `justfix.org` without the `/en` it wouldn't have any of the meta tags for social images, etc. Also this became a problem for verifying our domain for facebook. 

This PR splits off the Helmet part of our page Layout component and includes just the Helmet (with default/homepage metadata) on all of these redirect pages. 