### PR TITLE
Add Degular Semibold font file to CSS

### DIFF
--- a/src/styles/_design-system.scss
+++ b/src/styles/_design-system.scss
@@ -13,6 +13,14 @@
 }
 
 @font-face {
+  font-family: "Degular";
+  font-weight: 600;
+  font-style: normal;
+  src: url("../fonts/Degular-Semibold.woff2") format("woff2"),
+    url("../fonts/Degular-Semibold.woff") format("woff");
+}
+
+@font-face {
   font-family: "Degular Display";
   font-weight: normal;
   font-style: normal;


### PR DESCRIPTION
porting the safari fix from https://github.com/JustFixNYC/tenants2/pull/2409 [sc-11202]

previously:
<img width="410" alt="Screen Shot 2022-11-09 at 1 52 10 PM" src="https://user-images.githubusercontent.com/34112083/200949582-b03d1180-a05a-4531-ac8c-593de442cc24.png">

with the font file:
<img width="426" alt="Screen Shot 2022-11-09 at 1 52 22 PM" src="https://user-images.githubusercontent.com/34112083/200949622-67e3fa0c-9d73-4cde-80f2-22ff0602e4eb.png">
