### PR TITLE
add @justfix/util dependency & use storageFactory

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@contentful/rich-text-types": "^14.1.0",
     "@justfixnyc/contentful-common-strings": "^0.1.0",
     "@justfixnyc/geosearch-requester": "^0.0.6",
+    "@justfixnyc/util": "^0.4.1",
     "@lingui/react": "^2.8.3",
     "@reach/router": "1.3.4",
     "@types/classnames": "^2.2.9",

--- a/src/components/cookies-banner.tsx
+++ b/src/components/cookies-banner.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import classnames from "classnames";
 import FocusTrap from "focus-trap-react";
 import { I18n } from "@lingui/react";
+import { storageFactory } from "@justfixnyc/util";
 
 export const CookiesBanner = () => {
   const [modalIsActive, setModalActive] = useState(false);
@@ -11,14 +12,19 @@ export const CookiesBanner = () => {
   // Some notes on "localStorage"
   // https://blog.logrocket.com/using-localstorage-react-hooks/
   // https://stackoverflow.com/questions/65496028/gatsby-using-localstorage-to-store-data
+
+  // To avoid errors when localStorage is not available we use this factory
+  // https://github.com/JustFixNYC/justfix-ts/pull/41
+  const localStore = storageFactory(() => localStorage);
+
   useEffect(() => {
-    if (localStorage.getItem("closed") === "true") {
+    if (localStore.getItem("closed") === "true") {
       setBannerClosed(true);
     }
   }, []);
 
   const handleClick = () => {
-    localStorage.setItem("closed", "true");
+    localStore.setItem("closed", "true");
     setBannerClosed(true);
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2373,6 +2373,11 @@
   resolved "https://registry.yarnpkg.com/@justfixnyc/geosearch-requester/-/geosearch-requester-0.0.6.tgz#af3144a8b599e45ad3ce5c2190fc60da81106475"
   integrity sha512-wHsY9DbiQUp7H/KiQ4+ejTShR6lY3iagiFhw4VoP1kljyem+WIwEkiZNnvUHkOAQIkTtPulLaiKHEMpzaw9xZQ==
 
+"@justfixnyc/util@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@justfixnyc/util/-/util-0.4.1.tgz#98e9036f9c751520c79f7d59eaaa95d7c0619d8f"
+  integrity sha512-97eqofWvJ6jopBFhCPOKRHHChjE2XB38qCxA4SPkv8GWSc2CvUAghcQJGtPmHfKAwnhPdiv5Hlv+jZBe73ob0Q==
+
 "@lingui/babel-plugin-extract-messages@2.8.3":
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-2.8.3.tgz#3fd6bcc97f7fec35b8b39731cd1d99596636a166"


### PR DESCRIPTION
When using localStorage we were getting errors if it was available (browser settings). We [added a storageFactory function to our @justfix/util package](https://github.com/JustFixNYC/justfix-ts/pull/41) to better handle these issues. This PR adds that package as a dependency and uses the factory to manage localStorage operations. 

[sc-10520]

