### PR TITLE
Decrease page hero padding on mobile view

### DIFF
--- a/src/components/page-hero.tsx
+++ b/src/components/page-hero.tsx
@@ -43,7 +43,7 @@ const PageHero: React.FC<PageHeroInfo> = ({
       </div>
     ) : (
       <div className="columns is-marginless is-paddingless">
-        <div className="column is-8 px-9 py-10 p-6-mobile pt-13-mobile is-flex is-align-items-flex-end">
+        <div className="column is-8 px-9 py-10 p-6-mobile pt-9-mobile is-flex is-align-items-flex-end">
           <div className="is-flex-mobile is-flex-direction-column is-flex-grow-1">
             <div className="eyebrow is-large pb-4">{pageName}</div>
             <h1 className="mt-4">{description}</h1>


### PR DESCRIPTION
[shortcut link](https://app.shortcut.com/justfixnyc/story/11478/vertical-positioning-of-org-site-page-intro-text-on-mobile)