### PR TITLE
Add type weight and spacing consistency for cards with h3

### DIFF
--- a/src/pages/index.en.tsx
+++ b/src/pages/index.en.tsx
@@ -71,7 +71,9 @@ export const ProductCard: React.FC<ProductCardInfo> = (props) => {
         <div className="eyebrow is-small mb-5 mb-4-touch">
           {props.productName}
         </div>
-        <h3 className="mb-6 mb-5-touch">{props.title}</h3>
+        <h3 className="has-text-weight-semibold mb-6 mb-3-touch">
+          {props.title}
+        </h3>
         <div className="title is-4 mb-6 mb-5-touch">
           {documentToReactComponents(props.descriptionText.json)}
         </div>
@@ -193,7 +195,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
             <div className="has-background-warning mt-9">
               <div className="columns is-desktop is-marginless is-paddingless">
                 <div className="column jf-lc-featured is-marginless is-6 is-12-touch p-9">
-                  <div className="eyebrow is-large mb-6">
+                  <div className="eyebrow is-large mb-5 mb-4-touch">
                     <Trans>Featured article</Trans>
                   </div>
                   <Link
@@ -202,12 +204,12 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                   >
                     <ResponsiveElement
                       tagNames={{ desktop: "h2", touch: "h3" }}
-                      className="mb-6"
+                      className="has-text-weight-semibold mb-6"
                     >
                       {props.content.learningCenterPreviewArticles[0].title}
                     </ResponsiveElement>
                   </Link>
-                  <div className="eyebrow is-large mb-5">
+                  <div className="eyebrow is-large mb-4">
                     <Trans>Updated</Trans>{" "}
                     {props.content.learningCenterPreviewArticles[0].dateUpdated}
                   </div>
@@ -228,7 +230,7 @@ export const LandingPageScaffolding = (props: ContentfulContent) => (
                         to={`/learn/${props.content.learningCenterPreviewArticles[1].slug}`}
                         className="jf-link-article"
                       >
-                        <h3 className="mb-4">
+                        <h3 className="has-text-weight-semibold mb-4">
                           {props.content.learningCenterPreviewArticles[1].title}
                         </h3>
                       </Link>


### PR DESCRIPTION
[shortcut link](https://app.shortcut.com/justfixnyc/story/11476/typographic-weight-on-org-site-mobile-product-cards-and-homepage-learning-center-article-titles)