### PR TITLE
Learning center article dividers spacing issue

### DIFF
--- a/src/pages/partners.en.tsx
+++ b/src/pages/partners.en.tsx
@@ -151,7 +151,7 @@ const PartnershipCaseStudy: React.FC<PartnershipCaseStudyDetails> = ({
 }) => (
   <div className="columns has-background-info is-multiline">
     <div className="column is-12 is-paddingless pt-0-touch">
-      <div className="is-divider my-0-touch" />
+      <div className="is-divider m-0" />
     </div>
     <div className="column is-4 is-12-touch my-10 my-0-touch">
       <div className="eyebrow is-large mb-3">
@@ -171,7 +171,7 @@ const PartnershipCaseStudy: React.FC<PartnershipCaseStudyDetails> = ({
       })}
     </div>
     <div className="column is-12 is-paddingless pt-0-touch">
-      <div className="is-divider my-0-touch" />
+      <div className="is-divider m-0" />
     </div>
   </div>
 );
@@ -243,7 +243,7 @@ export const PartnersPageScaffolding = (props: ContentfulContent) => (
           </OutboundLink>
         </div>
         <div className="column is-8 has-background-info is-hidden-tablet pt-0 pb-7">
-          <div className="is-divider" />
+          <div className="is-divider m-0" />
           <h2 className="mt-6 mb-6">
             {props.content.collaborationBanner.label}
           </h2>

--- a/src/styles/_custom.scss
+++ b/src/styles/_custom.scss
@@ -156,7 +156,6 @@ $spacing-values: (
 
 .is-divider {
   border-top: 1px solid $justfix-black;
-  margin: 0;
 
   &.light {
     border-top: 1px solid $justfix-white;


### PR DESCRIPTION
caused by pushing a global divider margin change in #365 
also, removed `my-0-touch` since it's now redundant 

[sc-12195]