### PR TITLE
change twitter url to x

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -111,6 +111,7 @@ const Footer = () => (
           <SocialIcon
             className="mr-3"
             url="https://x.com/justfixorg"
+            network="twitter"
             target="_blank"
             rel="noopener noreferrer"
             bgColor="#FFF"

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -110,7 +110,7 @@ const Footer = () => (
           />
           <SocialIcon
             className="mr-3"
-            url="https://twitter.com/justfixorg"
+            url="https://x.com/justfixorg"
             target="_blank"
             rel="noopener noreferrer"
             bgColor="#FFF"


### PR DESCRIPTION
I think they are making the redirect really slow when using twitter.com, so these links are getting flagged as dead in our automated link checker. So this just changes to x.com. Then we need to force the icon to still be twitter, because we can't use the X icon without updating the react-social-icons package, and we're really behind in updates so then it needs a newer node version and that will take a bunch of time to work out the necessary gatsby migration. 